### PR TITLE
feat(backend): User domain — register/login/get/update 4 endpoints

### DIFF
--- a/backend/src/main/java/com/conduit/user/adapter/in/web/LoginRequest.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/LoginRequest.java
@@ -1,0 +1,8 @@
+package com.conduit.user.adapter.in.web;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank(message = "can't be blank") String email,
+    @NotBlank(message = "can't be blank") String password
+) {}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/RegisterRequest.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/RegisterRequest.java
@@ -1,0 +1,11 @@
+package com.conduit.user.adapter.in.web;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+    @NotBlank(message = "can't be blank") String username,
+    @NotBlank(message = "can't be blank") @Email(message = "is invalid") String email,
+    @NotBlank(message = "can't be blank") @Size(min = 8, message = "is too short") String password
+) {}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/UpdateUserRequest.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/UpdateUserRequest.java
@@ -1,0 +1,9 @@
+package com.conduit.user.adapter.in.web;
+
+public record UpdateUserRequest(
+    String email,
+    String username,
+    String password,
+    String bio,
+    String image
+) {}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/UserController.java
@@ -1,0 +1,76 @@
+package com.conduit.user.adapter.in.web;
+
+import com.conduit.shared.security.JwtTokenProvider;
+import com.conduit.user.domain.model.User;
+import com.conduit.user.domain.port.in.GetCurrentUserUseCase;
+import com.conduit.user.domain.port.in.LoginUserUseCase;
+import com.conduit.user.domain.port.in.RegisterUserUseCase;
+import com.conduit.user.domain.port.in.UpdateUserUseCase;
+import jakarta.validation.Valid;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class UserController {
+
+  private final RegisterUserUseCase registerUserUseCase;
+  private final LoginUserUseCase loginUserUseCase;
+  private final GetCurrentUserUseCase getCurrentUserUseCase;
+  private final UpdateUserUseCase updateUserUseCase;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public UserController(RegisterUserUseCase registerUserUseCase,
+      LoginUserUseCase loginUserUseCase, GetCurrentUserUseCase getCurrentUserUseCase,
+      UpdateUserUseCase updateUserUseCase, JwtTokenProvider jwtTokenProvider) {
+    this.registerUserUseCase = registerUserUseCase;
+    this.loginUserUseCase = loginUserUseCase;
+    this.getCurrentUserUseCase = getCurrentUserUseCase;
+    this.updateUserUseCase = updateUserUseCase;
+    this.jwtTokenProvider = jwtTokenProvider;
+  }
+
+  @PostMapping("/users")
+  public ResponseEntity<Map<String, UserResponse>> register(
+      @Valid @RequestBody Map<String, RegisterRequest> body) {
+    RegisterRequest req = body.get("user");
+    User user = registerUserUseCase.register(req.username(), req.email(), req.password());
+    String token = jwtTokenProvider.generateToken(user.getId());
+    return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
+  }
+
+  @PostMapping("/users/login")
+  public ResponseEntity<Map<String, UserResponse>> login(
+      @Valid @RequestBody Map<String, LoginRequest> body) {
+    LoginRequest req = body.get("user");
+    User user = loginUserUseCase.login(req.email(), req.password());
+    String token = jwtTokenProvider.generateToken(user.getId());
+    return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
+  }
+
+  @GetMapping("/user")
+  public ResponseEntity<Map<String, UserResponse>> getCurrentUser(Authentication authentication) {
+    Long userId = (Long) authentication.getPrincipal();
+    User user = getCurrentUserUseCase.getCurrentUser(userId);
+    String token = jwtTokenProvider.generateToken(user.getId());
+    return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
+  }
+
+  @PutMapping("/user")
+  public ResponseEntity<Map<String, UserResponse>> updateUser(Authentication authentication,
+      @RequestBody Map<String, UpdateUserRequest> body) {
+    Long userId = (Long) authentication.getPrincipal();
+    UpdateUserRequest req = body.get("user");
+    User user = updateUserUseCase.update(userId, req.email(), req.username(), req.password(),
+        req.bio(), req.image());
+    String token = jwtTokenProvider.generateToken(user.getId());
+    return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
+  }
+}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/UserResponse.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/UserResponse.java
@@ -1,0 +1,17 @@
+package com.conduit.user.adapter.in.web;
+
+import com.conduit.user.domain.model.User;
+
+public record UserResponse(
+    String email,
+    String token,
+    String username,
+    String bio,
+    String image
+) {
+
+  public static UserResponse from(User user, String token) {
+    return new UserResponse(user.getEmail(), token, user.getUsername(), user.getBio(),
+        user.getImage());
+  }
+}

--- a/backend/src/main/java/com/conduit/user/adapter/out/persistence/UserJpaEntity.java
+++ b/backend/src/main/java/com/conduit/user/adapter/out/persistence/UserJpaEntity.java
@@ -1,0 +1,51 @@
+package com.conduit.user.adapter.out.persistence;
+
+import com.conduit.shared.config.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class UserJpaEntity extends BaseEntity {
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false, unique = true)
+  private String username;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(columnDefinition = "TEXT")
+  private String bio;
+
+  @Column(length = 512)
+  private String image;
+
+  protected UserJpaEntity() {}
+
+  public UserJpaEntity(String email, String username, String password, String bio, String image) {
+    this.email = email;
+    this.username = username;
+    this.password = password;
+    this.bio = bio;
+    this.image = image;
+  }
+
+  public String getEmail() { return email; }
+  public void setEmail(String email) { this.email = email; }
+
+  public String getUsername() { return username; }
+  public void setUsername(String username) { this.username = username; }
+
+  public String getPassword() { return password; }
+  public void setPassword(String password) { this.password = password; }
+
+  public String getBio() { return bio; }
+  public void setBio(String bio) { this.bio = bio; }
+
+  public String getImage() { return image; }
+  public void setImage(String image) { this.image = image; }
+}

--- a/backend/src/main/java/com/conduit/user/adapter/out/persistence/UserJpaRepository.java
+++ b/backend/src/main/java/com/conduit/user/adapter/out/persistence/UserJpaRepository.java
@@ -1,0 +1,15 @@
+package com.conduit.user.adapter.out.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
+
+  Optional<UserJpaEntity> findByEmail(String email);
+
+  Optional<UserJpaEntity> findByUsername(String username);
+
+  boolean existsByEmail(String email);
+
+  boolean existsByUsername(String username);
+}

--- a/backend/src/main/java/com/conduit/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,65 @@
+package com.conduit.user.adapter.out.persistence;
+
+import com.conduit.user.domain.model.User;
+import com.conduit.user.domain.port.out.UserRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserPersistenceAdapter implements UserRepository {
+
+  private final UserJpaRepository jpaRepository;
+
+  public UserPersistenceAdapter(UserJpaRepository jpaRepository) {
+    this.jpaRepository = jpaRepository;
+  }
+
+  @Override
+  public User save(User user) {
+    UserJpaEntity entity;
+    if (user.getId() != null) {
+      entity = jpaRepository.findById(user.getId())
+          .orElseThrow(() -> new IllegalStateException("User not found: " + user.getId()));
+      entity.setEmail(user.getEmail());
+      entity.setUsername(user.getUsername());
+      entity.setPassword(user.getPassword());
+      entity.setBio(user.getBio());
+      entity.setImage(user.getImage());
+    } else {
+      entity = new UserJpaEntity(user.getEmail(), user.getUsername(), user.getPassword(),
+          user.getBio(), user.getImage());
+    }
+    UserJpaEntity saved = jpaRepository.save(entity);
+    return toDomain(saved);
+  }
+
+  @Override
+  public Optional<User> findById(Long id) {
+    return jpaRepository.findById(id).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<User> findByEmail(String email) {
+    return jpaRepository.findByEmail(email).map(this::toDomain);
+  }
+
+  @Override
+  public Optional<User> findByUsername(String username) {
+    return jpaRepository.findByUsername(username).map(this::toDomain);
+  }
+
+  @Override
+  public boolean existsByEmail(String email) {
+    return jpaRepository.existsByEmail(email);
+  }
+
+  @Override
+  public boolean existsByUsername(String username) {
+    return jpaRepository.existsByUsername(username);
+  }
+
+  private User toDomain(UserJpaEntity entity) {
+    return new User(entity.getId(), entity.getEmail(), entity.getUsername(), entity.getPassword(),
+        entity.getBio(), entity.getImage());
+  }
+}

--- a/backend/src/main/java/com/conduit/user/application/service/UserService.java
+++ b/backend/src/main/java/com/conduit/user/application/service/UserService.java
@@ -1,0 +1,78 @@
+package com.conduit.user.application.service;
+
+import com.conduit.shared.exception.ApiException;
+import com.conduit.user.domain.model.User;
+import com.conduit.user.domain.port.in.GetCurrentUserUseCase;
+import com.conduit.user.domain.port.in.LoginUserUseCase;
+import com.conduit.user.domain.port.in.RegisterUserUseCase;
+import com.conduit.user.domain.port.in.UpdateUserUseCase;
+import com.conduit.user.domain.port.out.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UserService
+    implements RegisterUserUseCase, LoginUserUseCase, GetCurrentUserUseCase, UpdateUserUseCase {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  @Override
+  public User register(String username, String email, String password) {
+    if (userRepository.existsByEmail(email)) {
+      throw new ApiException.ValidationException("email has already been taken");
+    }
+    if (userRepository.existsByUsername(username)) {
+      throw new ApiException.ValidationException("username has already been taken");
+    }
+
+    User user = User.create(email, username, passwordEncoder.encode(password));
+    return userRepository.save(user);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public User login(String email, String password) {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new ApiException.UnauthorizedException("invalid email or password"));
+
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new ApiException.UnauthorizedException("invalid email or password");
+    }
+
+    return user;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public User getCurrentUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new ApiException.NotFoundException("user not found"));
+  }
+
+  @Override
+  public User update(Long userId, String email, String username, String password, String bio,
+      String image) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new ApiException.NotFoundException("user not found"));
+
+    if (email != null && !email.equals(user.getEmail()) && userRepository.existsByEmail(email)) {
+      throw new ApiException.ValidationException("email has already been taken");
+    }
+    if (username != null && !username.equals(user.getUsername())
+        && userRepository.existsByUsername(username)) {
+      throw new ApiException.ValidationException("username has already been taken");
+    }
+
+    String hashedPassword = password != null ? passwordEncoder.encode(password) : null;
+    user.update(email, username, hashedPassword, bio, image);
+    return userRepository.save(user);
+  }
+}

--- a/backend/src/main/java/com/conduit/user/domain/model/User.java
+++ b/backend/src/main/java/com/conduit/user/domain/model/User.java
@@ -1,0 +1,40 @@
+package com.conduit.user.domain.model;
+
+public class User {
+
+  private Long id;
+  private String email;
+  private String username;
+  private String password;
+  private String bio;
+  private String image;
+
+  public User(Long id, String email, String username, String password, String bio, String image) {
+    this.id = id;
+    this.email = email;
+    this.username = username;
+    this.password = password;
+    this.bio = bio;
+    this.image = image;
+  }
+
+  public static User create(String email, String username, String hashedPassword) {
+    return new User(null, email, username, hashedPassword, null, null);
+  }
+
+  public void update(String email, String username, String hashedPassword, String bio,
+      String image) {
+    if (email != null) this.email = email;
+    if (username != null) this.username = username;
+    if (hashedPassword != null) this.password = hashedPassword;
+    if (bio != null) this.bio = bio;
+    if (image != null) this.image = image;
+  }
+
+  public Long getId() { return id; }
+  public String getEmail() { return email; }
+  public String getUsername() { return username; }
+  public String getPassword() { return password; }
+  public String getBio() { return bio; }
+  public String getImage() { return image; }
+}

--- a/backend/src/main/java/com/conduit/user/domain/port/in/GetCurrentUserUseCase.java
+++ b/backend/src/main/java/com/conduit/user/domain/port/in/GetCurrentUserUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.user.domain.port.in;
+
+import com.conduit.user.domain.model.User;
+
+public interface GetCurrentUserUseCase {
+
+  User getCurrentUser(Long userId);
+}

--- a/backend/src/main/java/com/conduit/user/domain/port/in/LoginUserUseCase.java
+++ b/backend/src/main/java/com/conduit/user/domain/port/in/LoginUserUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.user.domain.port.in;
+
+import com.conduit.user.domain.model.User;
+
+public interface LoginUserUseCase {
+
+  User login(String email, String password);
+}

--- a/backend/src/main/java/com/conduit/user/domain/port/in/RegisterUserUseCase.java
+++ b/backend/src/main/java/com/conduit/user/domain/port/in/RegisterUserUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.user.domain.port.in;
+
+import com.conduit.user.domain.model.User;
+
+public interface RegisterUserUseCase {
+
+  User register(String username, String email, String password);
+}

--- a/backend/src/main/java/com/conduit/user/domain/port/in/UpdateUserUseCase.java
+++ b/backend/src/main/java/com/conduit/user/domain/port/in/UpdateUserUseCase.java
@@ -1,0 +1,9 @@
+package com.conduit.user.domain.port.in;
+
+import com.conduit.user.domain.model.User;
+
+public interface UpdateUserUseCase {
+
+  User update(Long userId, String email, String username, String password, String bio,
+      String image);
+}

--- a/backend/src/main/java/com/conduit/user/domain/port/out/UserRepository.java
+++ b/backend/src/main/java/com/conduit/user/domain/port/out/UserRepository.java
@@ -1,0 +1,19 @@
+package com.conduit.user.domain.port.out;
+
+import com.conduit.user.domain.model.User;
+import java.util.Optional;
+
+public interface UserRepository {
+
+  User save(User user);
+
+  Optional<User> findById(Long id);
+
+  Optional<User> findByEmail(String email);
+
+  Optional<User> findByUsername(String username);
+
+  boolean existsByEmail(String email);
+
+  boolean existsByUsername(String username);
+}

--- a/backend/src/test/java/com/conduit/user/adapter/in/web/UserControllerTest.java
+++ b/backend/src/test/java/com/conduit/user/adapter/in/web/UserControllerTest.java
@@ -1,0 +1,206 @@
+package com.conduit.user.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.conduit.shared.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private JwtTokenProvider jwtTokenProvider;
+
+  private String registerUser(String username, String email, String password) throws Exception {
+    String body = """
+        {"user":{"username":"%s","email":"%s","password":"%s"}}
+        """.formatted(username, email, password);
+
+    MvcResult result = mockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    return result.getResponse().getContentAsString();
+  }
+
+  @Nested
+  @DisplayName("POST /api/users")
+  class Registration {
+
+    @Test
+    @DisplayName("should register a new user")
+    void success() throws Exception {
+      mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"username":"jacob","email":"jake@jake.com","password":"jakejake1"}}
+                  """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.user.email").value("jake@jake.com"))
+          .andExpect(jsonPath("$.user.username").value("jacob"))
+          .andExpect(jsonPath("$.user.token").isNotEmpty())
+          .andExpect(jsonPath("$.user.bio").doesNotExist())
+          .andExpect(jsonPath("$.user.image").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("should return 422 for duplicate email")
+    void duplicateEmail() throws Exception {
+      registerUser("first", "dupe@test.com", "password123");
+
+      mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"username":"second","email":"dupe@test.com","password":"password123"}}
+                  """))
+          .andExpect(status().isUnprocessableEntity())
+          .andExpect(jsonPath("$.errors").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("should return 422 for duplicate username")
+    void duplicateUsername() throws Exception {
+      registerUser("taken", "first@test.com", "password123");
+
+      mockMvc.perform(post("/api/users")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"username":"taken","email":"second@test.com","password":"password123"}}
+                  """))
+          .andExpect(status().isUnprocessableEntity());
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/users/login")
+  class Login {
+
+    @Test
+    @DisplayName("should login with valid credentials")
+    void success() throws Exception {
+      registerUser("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc.perform(post("/api/users/login")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"email":"jake@jake.com","password":"jakejake1"}}
+                  """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.user.email").value("jake@jake.com"))
+          .andExpect(jsonPath("$.user.username").value("jacob"))
+          .andExpect(jsonPath("$.user.token").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("should return 401 for wrong password")
+    void wrongPassword() throws Exception {
+      registerUser("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc.perform(post("/api/users/login")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"email":"jake@jake.com","password":"wrongwrong"}}
+                  """))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should return 401 for unknown email")
+    void unknownEmail() throws Exception {
+      mockMvc.perform(post("/api/users/login")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"email":"noone@test.com","password":"password123"}}
+                  """))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/user")
+  class GetCurrentUser {
+
+    @Test
+    @DisplayName("should return current user with valid JWT")
+    void success() throws Exception {
+      registerUser("jacob", "jake@jake.com", "jakejake1");
+
+      // Login to get a valid token
+      MvcResult loginResult = mockMvc.perform(post("/api/users/login")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"email":"jake@jake.com","password":"jakejake1"}}
+                  """))
+          .andExpect(status().isOk())
+          .andReturn();
+
+      String token = com.jayway.jsonpath.JsonPath
+          .read(loginResult.getResponse().getContentAsString(), "$.user.token");
+
+      mockMvc.perform(get("/api/user")
+              .header("Authorization", "Token " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.user.email").value("jake@jake.com"))
+          .andExpect(jsonPath("$.user.username").value("jacob"));
+    }
+
+    @Test
+    @DisplayName("should return 401 without JWT")
+    void unauthorized() throws Exception {
+      mockMvc.perform(get("/api/user"))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /api/user")
+  class UpdateUser {
+
+    @Test
+    @DisplayName("should update user bio and image")
+    void success() throws Exception {
+      registerUser("jacob", "jake@jake.com", "jakejake1");
+
+      MvcResult loginResult = mockMvc.perform(post("/api/users/login")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"email":"jake@jake.com","password":"jakejake1"}}
+                  """))
+          .andExpect(status().isOk())
+          .andReturn();
+
+      String token = com.jayway.jsonpath.JsonPath
+          .read(loginResult.getResponse().getContentAsString(), "$.user.token");
+
+      mockMvc.perform(put("/api/user")
+              .header("Authorization", "Token " + token)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("""
+                  {"user":{"bio":"I like to code","image":"https://i.imgur.com/test.jpg"}}
+                  """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.user.bio").value("I like to code"))
+          .andExpect(jsonPath("$.user.image").value("https://i.imgur.com/test.jpg"))
+          .andExpect(jsonPath("$.user.email").value("jake@jake.com"));
+    }
+  }
+}

--- a/backend/src/test/java/com/conduit/user/application/service/UserServiceTest.java
+++ b/backend/src/test/java/com/conduit/user/application/service/UserServiceTest.java
@@ -1,0 +1,175 @@
+package com.conduit.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.conduit.shared.exception.ApiException;
+import com.conduit.user.domain.model.User;
+import com.conduit.user.domain.port.out.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PasswordEncoder passwordEncoder;
+  private UserService userService;
+
+  @BeforeEach
+  void setUp() {
+    userService = new UserService(userRepository, passwordEncoder);
+  }
+
+  @Nested
+  @DisplayName("register")
+  class Register {
+
+    @Test
+    @DisplayName("should register a new user successfully")
+    void success() {
+      when(userRepository.existsByEmail("test@test.com")).thenReturn(false);
+      when(userRepository.existsByUsername("testuser")).thenReturn(false);
+      when(passwordEncoder.encode("password123")).thenReturn("hashed");
+      when(userRepository.save(any(User.class)))
+          .thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            return new User(1L, u.getEmail(), u.getUsername(), u.getPassword(), u.getBio(),
+                u.getImage());
+          });
+
+      User result = userService.register("testuser", "test@test.com", "password123");
+
+      assertThat(result.getId()).isEqualTo(1L);
+      assertThat(result.getEmail()).isEqualTo("test@test.com");
+      assertThat(result.getUsername()).isEqualTo("testuser");
+      assertThat(result.getPassword()).isEqualTo("hashed");
+    }
+
+    @Test
+    @DisplayName("should throw when email is already taken")
+    void duplicateEmail() {
+      when(userRepository.existsByEmail("taken@test.com")).thenReturn(true);
+
+      assertThatThrownBy(() -> userService.register("user", "taken@test.com", "password123"))
+          .isInstanceOf(ApiException.ValidationException.class)
+          .hasMessageContaining("email has already been taken");
+    }
+
+    @Test
+    @DisplayName("should throw when username is already taken")
+    void duplicateUsername() {
+      when(userRepository.existsByEmail(anyString())).thenReturn(false);
+      when(userRepository.existsByUsername("taken")).thenReturn(true);
+
+      assertThatThrownBy(() -> userService.register("taken", "new@test.com", "password123"))
+          .isInstanceOf(ApiException.ValidationException.class)
+          .hasMessageContaining("username has already been taken");
+    }
+  }
+
+  @Nested
+  @DisplayName("login")
+  class Login {
+
+    @Test
+    @DisplayName("should login with valid credentials")
+    void success() {
+      User user = new User(1L, "test@test.com", "testuser", "hashed", null, null);
+      when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+      when(passwordEncoder.matches("password123", "hashed")).thenReturn(true);
+
+      User result = userService.login("test@test.com", "password123");
+
+      assertThat(result.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("should throw when email not found")
+    void emailNotFound() {
+      when(userRepository.findByEmail("wrong@test.com")).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> userService.login("wrong@test.com", "password123"))
+          .isInstanceOf(ApiException.UnauthorizedException.class);
+    }
+
+    @Test
+    @DisplayName("should throw when password is wrong")
+    void wrongPassword() {
+      User user = new User(1L, "test@test.com", "testuser", "hashed", null, null);
+      when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+      when(passwordEncoder.matches("wrong", "hashed")).thenReturn(false);
+
+      assertThatThrownBy(() -> userService.login("test@test.com", "wrong"))
+          .isInstanceOf(ApiException.UnauthorizedException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("getCurrentUser")
+  class GetCurrentUser {
+
+    @Test
+    @DisplayName("should return current user")
+    void success() {
+      User user = new User(1L, "test@test.com", "testuser", "hashed", "bio", null);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+      User result = userService.getCurrentUser(1L);
+
+      assertThat(result.getUsername()).isEqualTo("testuser");
+    }
+
+    @Test
+    @DisplayName("should throw when user not found")
+    void notFound() {
+      when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> userService.getCurrentUser(999L))
+          .isInstanceOf(ApiException.NotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("update")
+  class Update {
+
+    @Test
+    @DisplayName("should update user fields")
+    void success() {
+      User existing = new User(1L, "old@test.com", "olduser", "hashed", null, null);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(existing));
+      when(userRepository.existsByEmail("new@test.com")).thenReturn(false);
+      when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      User result = userService.update(1L, "new@test.com", null, null, "new bio", null);
+
+      assertThat(result.getEmail()).isEqualTo("new@test.com");
+      assertThat(result.getBio()).isEqualTo("new bio");
+      assertThat(result.getUsername()).isEqualTo("olduser");
+    }
+
+    @Test
+    @DisplayName("should throw when new email is taken by another user")
+    void duplicateEmail() {
+      User existing = new User(1L, "old@test.com", "user", "hashed", null, null);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(existing));
+      when(userRepository.existsByEmail("taken@test.com")).thenReturn(true);
+
+      assertThatThrownBy(
+          () -> userService.update(1L, "taken@test.com", null, null, null, null))
+          .isInstanceOf(ApiException.ValidationException.class)
+          .hasMessageContaining("email has already been taken");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- User 도메인 모델 (Hexagonal Architecture: domain/port/application/adapter)
- 4 REST 엔드포인트: `POST /api/users`, `POST /api/users/login`, `GET /api/user`, `PUT /api/user`
- BCrypt 비밀번호 해싱 + JWT 토큰 생성
- 중복 email/username 검증 → 422 에러 (RealWorld 포맷)
- 15개 Java 클래스 (domain 1 + ports 5 + service 1 + DTOs 4 + JPA 3 + controller 1)

## Test Plan

### 1. 단위 테스트 (10건, Mockito)
- [x] register — 성공 / 중복 email / 중복 username
- [x] login — 성공 / email 미존재 / 비밀번호 불일치
- [x] getCurrentUser — 성공 / 미존재
- [x] update — 성공 / 중복 email

### 2. 통합 테스트 (9건, MockMvc + H2)
- [x] POST /api/users — 성공 / 중복 email / 중복 username
- [x] POST /api/users/login — 성공 / 잘못된 비밀번호 / 미존재 email
- [x] GET /api/user — JWT 성공 / 미인증 401
- [x] PUT /api/user — bio/image 수정 성공

### 3. 빌드 검증
- [x] `./gradlew clean test` BUILD SUCCESSFUL (27 tests total)

Closes #7

**Flow Mode**: add (auto-detected, type:feature label, 0 negative signals — ADR-0032)