### PR TITLE
feat(backend): Article CRUD — 생성/조회/수정/삭제 + Slug 자동생성

### DIFF
--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
@@ -1,0 +1,93 @@
+package com.conduit.article.adapter.in.web;
+
+import com.conduit.article.domain.model.Article;
+import com.conduit.article.domain.port.in.CreateArticleUseCase;
+import com.conduit.article.domain.port.in.DeleteArticleUseCase;
+import com.conduit.article.domain.port.in.GetArticleUseCase;
+import com.conduit.article.domain.port.in.UpdateArticleUseCase;
+import com.conduit.shared.exception.ApiException;
+import com.conduit.user.domain.model.User;
+import com.conduit.user.domain.port.out.UserRepository;
+import jakarta.validation.Valid;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class ArticleController {
+
+  private final CreateArticleUseCase createArticleUseCase;
+  private final GetArticleUseCase getArticleUseCase;
+  private final UpdateArticleUseCase updateArticleUseCase;
+  private final DeleteArticleUseCase deleteArticleUseCase;
+  private final UserRepository userRepository;
+
+  public ArticleController(
+      CreateArticleUseCase createArticleUseCase,
+      GetArticleUseCase getArticleUseCase,
+      UpdateArticleUseCase updateArticleUseCase,
+      DeleteArticleUseCase deleteArticleUseCase,
+      UserRepository userRepository) {
+    this.createArticleUseCase = createArticleUseCase;
+    this.getArticleUseCase = getArticleUseCase;
+    this.updateArticleUseCase = updateArticleUseCase;
+    this.deleteArticleUseCase = deleteArticleUseCase;
+    this.userRepository = userRepository;
+  }
+
+  @PostMapping("/articles")
+  public ResponseEntity<Map<String, ArticleResponse>> createArticle(
+      Authentication authentication,
+      @Valid @RequestBody Map<String, CreateArticleRequest> body) {
+    Long userId = (Long) authentication.getPrincipal();
+    CreateArticleRequest req = body.get("article");
+    Article article =
+        createArticleUseCase.create(
+            req.title(), req.description(), req.body(), userId, req.tagList());
+    User author = findAuthor(article.getAuthorId());
+    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
+  }
+
+  @GetMapping("/articles/{slug}")
+  public ResponseEntity<Map<String, ArticleResponse>> getArticle(@PathVariable String slug) {
+    Article article = getArticleUseCase.getBySlug(slug);
+    User author = findAuthor(article.getAuthorId());
+    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
+  }
+
+  @PutMapping("/articles/{slug}")
+  public ResponseEntity<Map<String, ArticleResponse>> updateArticle(
+      Authentication authentication,
+      @PathVariable String slug,
+      @RequestBody Map<String, UpdateArticleRequest> body) {
+    Long userId = (Long) authentication.getPrincipal();
+    UpdateArticleRequest req = body.get("article");
+    Article article =
+        updateArticleUseCase.update(slug, userId, req.title(), req.description(), req.body());
+    User author = findAuthor(article.getAuthorId());
+    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
+  }
+
+  @DeleteMapping("/articles/{slug}")
+  public ResponseEntity<Void> deleteArticle(
+      Authentication authentication, @PathVariable String slug) {
+    Long userId = (Long) authentication.getPrincipal();
+    deleteArticleUseCase.delete(slug, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private User findAuthor(Long authorId) {
+    return userRepository
+        .findById(authorId)
+        .orElseThrow(() -> new ApiException.NotFoundException("author not found"));
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleResponse.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleResponse.java
@@ -1,0 +1,33 @@
+package com.conduit.article.adapter.in.web;
+
+import com.conduit.article.domain.model.Article;
+import com.conduit.user.domain.model.User;
+import java.time.Instant;
+import java.util.List;
+
+public record ArticleResponse(
+    String slug,
+    String title,
+    String description,
+    String body,
+    List<String> tagList,
+    Instant createdAt,
+    Instant updatedAt,
+    int favoritesCount,
+    AuthorResponse author) {
+
+  public static ArticleResponse from(Article article, User author) {
+    return new ArticleResponse(
+        article.getSlug(),
+        article.getTitle(),
+        article.getDescription(),
+        article.getBody(),
+        article.getTagList(),
+        article.getCreatedAt(),
+        article.getUpdatedAt(),
+        article.getFavoritesCount(),
+        new AuthorResponse(author.getUsername(), author.getBio(), author.getImage()));
+  }
+
+  public record AuthorResponse(String username, String bio, String image) {}
+}

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/CreateArticleRequest.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/CreateArticleRequest.java
@@ -1,0 +1,10 @@
+package com.conduit.article.adapter.in.web;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record CreateArticleRequest(
+    @NotBlank(message = "can't be blank") String title,
+    @NotBlank(message = "can't be blank") String description,
+    @NotBlank(message = "can't be blank") String body,
+    List<String> tagList) {}

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/UpdateArticleRequest.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/UpdateArticleRequest.java
@@ -1,0 +1,3 @@
+package com.conduit.article.adapter.in.web;
+
+public record UpdateArticleRequest(String title, String description, String body) {}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticleJpaEntity.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticleJpaEntity.java
@@ -1,0 +1,114 @@
+package com.conduit.article.adapter.out.persistence;
+
+import com.conduit.shared.config.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "articles")
+public class ArticleJpaEntity extends BaseEntity {
+
+  @Column(nullable = false, unique = true)
+  private String slug;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false, length = 512)
+  private String description;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String body;
+
+  @Column(name = "author_id", nullable = false)
+  private Long authorId;
+
+  @Column(name = "favorites_count", nullable = false)
+  private int favoritesCount;
+
+  @ManyToMany
+  @JoinTable(
+      name = "article_tags",
+      joinColumns = @JoinColumn(name = "article_id"),
+      inverseJoinColumns = @JoinColumn(name = "tag_id"))
+  private List<TagJpaEntity> tags = new ArrayList<>();
+
+  protected ArticleJpaEntity() {}
+
+  public ArticleJpaEntity(
+      String slug,
+      String title,
+      String description,
+      String body,
+      Long authorId,
+      int favoritesCount) {
+    this.slug = slug;
+    this.title = title;
+    this.description = description;
+    this.body = body;
+    this.authorId = authorId;
+    this.favoritesCount = favoritesCount;
+  }
+
+  public String getSlug() {
+    return slug;
+  }
+
+  public void setSlug(String slug) {
+    this.slug = slug;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
+
+  public Long getAuthorId() {
+    return authorId;
+  }
+
+  public void setAuthorId(Long authorId) {
+    this.authorId = authorId;
+  }
+
+  public int getFavoritesCount() {
+    return favoritesCount;
+  }
+
+  public void setFavoritesCount(int favoritesCount) {
+    this.favoritesCount = favoritesCount;
+  }
+
+  public List<TagJpaEntity> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<TagJpaEntity> tags) {
+    this.tags = tags;
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticleJpaRepository.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticleJpaRepository.java
@@ -1,0 +1,11 @@
+package com.conduit.article.adapter.out.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleJpaRepository extends JpaRepository<ArticleJpaEntity, Long> {
+
+  Optional<ArticleJpaEntity> findBySlug(String slug);
+
+  boolean existsBySlug(String slug);
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticlePersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticlePersistenceAdapter.java
@@ -1,0 +1,102 @@
+package com.conduit.article.adapter.out.persistence;
+
+import com.conduit.article.domain.model.Article;
+import com.conduit.article.domain.port.out.ArticleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ArticlePersistenceAdapter implements ArticleRepository {
+
+  private final ArticleJpaRepository articleJpaRepository;
+  private final TagJpaRepository tagJpaRepository;
+
+  public ArticlePersistenceAdapter(
+      ArticleJpaRepository articleJpaRepository, TagJpaRepository tagJpaRepository) {
+    this.articleJpaRepository = articleJpaRepository;
+    this.tagJpaRepository = tagJpaRepository;
+  }
+
+  @Override
+  public Article save(Article article) {
+    ArticleJpaEntity entity;
+    if (article.getId() != null) {
+      entity =
+          articleJpaRepository
+              .findById(article.getId())
+              .orElseThrow(
+                  () -> new IllegalStateException("Article not found: " + article.getId()));
+      entity.setSlug(article.getSlug());
+      entity.setTitle(article.getTitle());
+      entity.setDescription(article.getDescription());
+      entity.setBody(article.getBody());
+      entity.setAuthorId(article.getAuthorId());
+      entity.setFavoritesCount(article.getFavoritesCount());
+    } else {
+      entity =
+          new ArticleJpaEntity(
+              article.getSlug(),
+              article.getTitle(),
+              article.getDescription(),
+              article.getBody(),
+              article.getAuthorId(),
+              article.getFavoritesCount());
+    }
+
+    entity.setTags(resolveTagEntities(article.getTagList()));
+    ArticleJpaEntity saved = articleJpaRepository.save(entity);
+    return toDomain(saved);
+  }
+
+  @Override
+  public Optional<Article> findBySlug(String slug) {
+    return articleJpaRepository.findBySlug(slug).map(this::toDomain);
+  }
+
+  @Override
+  public void delete(Article article) {
+    articleJpaRepository
+        .findById(article.getId())
+        .ifPresent(articleJpaRepository::delete);
+  }
+
+  @Override
+  public boolean existsBySlug(String slug) {
+    return articleJpaRepository.existsBySlug(slug);
+  }
+
+  private List<TagJpaEntity> resolveTagEntities(List<String> tagNames) {
+    if (tagNames == null || tagNames.isEmpty()) {
+      return new ArrayList<>();
+    }
+
+    List<TagJpaEntity> result = new ArrayList<>();
+    for (String tagName : tagNames) {
+      TagJpaEntity tagEntity =
+          tagJpaRepository
+              .findByName(tagName)
+              .orElseGet(
+                  () -> tagJpaRepository.save(new TagJpaEntity(tagName)));
+      result.add(tagEntity);
+    }
+    return result;
+  }
+
+  private Article toDomain(ArticleJpaEntity entity) {
+    List<String> tagNames = entity.getTags().stream().map(TagJpaEntity::getName).toList();
+
+    return new Article(
+        entity.getId(),
+        entity.getSlug(),
+        entity.getTitle(),
+        entity.getDescription(),
+        entity.getBody(),
+        entity.getAuthorId(),
+        tagNames,
+        entity.getFavoritesCount(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/TagJpaEntity.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/TagJpaEntity.java
@@ -1,0 +1,38 @@
+package com.conduit.article.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tags")
+public class TagJpaEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String name;
+
+  protected TagJpaEntity() {}
+
+  public TagJpaEntity(String name) {
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/TagJpaRepository.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/TagJpaRepository.java
@@ -1,0 +1,12 @@
+package com.conduit.article.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagJpaRepository extends JpaRepository<TagJpaEntity, Long> {
+
+  Optional<TagJpaEntity> findByName(String name);
+
+  List<TagJpaEntity> findByNameIn(List<String> names);
+}

--- a/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
+++ b/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
@@ -1,0 +1,90 @@
+package com.conduit.article.application.service;
+
+import com.conduit.article.domain.model.Article;
+import com.conduit.article.domain.port.in.CreateArticleUseCase;
+import com.conduit.article.domain.port.in.DeleteArticleUseCase;
+import com.conduit.article.domain.port.in.GetArticleUseCase;
+import com.conduit.article.domain.port.in.UpdateArticleUseCase;
+import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.shared.exception.ApiException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ArticleService
+    implements CreateArticleUseCase, GetArticleUseCase, UpdateArticleUseCase, DeleteArticleUseCase {
+
+  private final ArticleRepository articleRepository;
+
+  public ArticleService(ArticleRepository articleRepository) {
+    this.articleRepository = articleRepository;
+  }
+
+  @Override
+  public Article create(
+      String title, String description, String body, Long authorId, List<String> tagList) {
+    Article article = Article.create(title, description, body, authorId, tagList);
+
+    String baseSlug = article.getSlug();
+    String slug = baseSlug;
+    int suffix = 1;
+    while (articleRepository.existsBySlug(slug)) {
+      slug = baseSlug + "-" + suffix;
+      suffix++;
+    }
+    article.setSlug(slug);
+
+    return articleRepository.save(article);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Article getBySlug(String slug) {
+    return articleRepository
+        .findBySlug(slug)
+        .orElseThrow(() -> new ApiException.NotFoundException("article not found"));
+  }
+
+  @Override
+  public Article update(String slug, Long userId, String title, String description, String body) {
+    Article article =
+        articleRepository
+            .findBySlug(slug)
+            .orElseThrow(() -> new ApiException.NotFoundException("article not found"));
+
+    if (!article.getAuthorId().equals(userId)) {
+      throw new ApiException.ForbiddenException("you are not the author of this article");
+    }
+
+    article.update(title, description, body);
+
+    if (title != null) {
+      String baseSlug = article.getSlug();
+      String newSlug = baseSlug;
+      int suffix = 1;
+      while (articleRepository.existsBySlug(newSlug)) {
+        newSlug = baseSlug + "-" + suffix;
+        suffix++;
+      }
+      article.setSlug(newSlug);
+    }
+
+    return articleRepository.save(article);
+  }
+
+  @Override
+  public void delete(String slug, Long userId) {
+    Article article =
+        articleRepository
+            .findBySlug(slug)
+            .orElseThrow(() -> new ApiException.NotFoundException("article not found"));
+
+    if (!article.getAuthorId().equals(userId)) {
+      throw new ApiException.ForbiddenException("you are not the author of this article");
+    }
+
+    articleRepository.delete(article);
+  }
+}

--- a/backend/src/main/java/com/conduit/article/domain/model/Article.java
+++ b/backend/src/main/java/com/conduit/article/domain/model/Article.java
@@ -1,0 +1,122 @@
+package com.conduit.article.domain.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Article {
+
+  private Long id;
+  private String slug;
+  private String title;
+  private String description;
+  private String body;
+  private Long authorId;
+  private List<String> tagList;
+  private int favoritesCount;
+  private Instant createdAt;
+  private Instant updatedAt;
+
+  public Article(
+      Long id,
+      String slug,
+      String title,
+      String description,
+      String body,
+      Long authorId,
+      List<String> tagList,
+      int favoritesCount,
+      Instant createdAt,
+      Instant updatedAt) {
+    this.id = id;
+    this.slug = slug;
+    this.title = title;
+    this.description = description;
+    this.body = body;
+    this.authorId = authorId;
+    this.tagList = tagList != null ? new ArrayList<>(tagList) : new ArrayList<>();
+    this.favoritesCount = favoritesCount;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public static Article create(
+      String title, String description, String body, Long authorId, List<String> tagList) {
+    String slug = generateSlug(title);
+    return new Article(null, slug, title, description, body, authorId, tagList, 0, null, null);
+  }
+
+  public void update(String title, String description, String body) {
+    if (title != null) {
+      this.title = title;
+      this.slug = generateSlug(title);
+    }
+    if (description != null) {
+      this.description = description;
+    }
+    if (body != null) {
+      this.body = body;
+    }
+  }
+
+  static String generateSlug(String title) {
+    if (title == null || title.isBlank()) {
+      return "";
+    }
+    String slug =
+        title
+            .toLowerCase()
+            .replaceAll("[^a-z0-9]+", "-")
+            .replaceAll("^-+", "")
+            .replaceAll("-+$", "");
+    if (slug.length() > 100) {
+      slug = slug.substring(0, 100);
+      slug = slug.replaceAll("-+$", "");
+    }
+    return slug;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getSlug() {
+    return slug;
+  }
+
+  public void setSlug(String slug) {
+    this.slug = slug;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public Long getAuthorId() {
+    return authorId;
+  }
+
+  public List<String> getTagList() {
+    return tagList;
+  }
+
+  public int getFavoritesCount() {
+    return favoritesCount;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/CreateArticleUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/CreateArticleUseCase.java
@@ -1,0 +1,10 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+import java.util.List;
+
+public interface CreateArticleUseCase {
+
+  Article create(
+      String title, String description, String body, Long authorId, List<String> tagList);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/DeleteArticleUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/DeleteArticleUseCase.java
@@ -1,0 +1,6 @@
+package com.conduit.article.domain.port.in;
+
+public interface DeleteArticleUseCase {
+
+  void delete(String slug, Long userId);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/GetArticleUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/GetArticleUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+
+public interface GetArticleUseCase {
+
+  Article getBySlug(String slug);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/UpdateArticleUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/UpdateArticleUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+
+public interface UpdateArticleUseCase {
+
+  Article update(String slug, Long userId, String title, String description, String body);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/out/ArticleRepository.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/out/ArticleRepository.java
@@ -1,0 +1,15 @@
+package com.conduit.article.domain.port.out;
+
+import com.conduit.article.domain.model.Article;
+import java.util.Optional;
+
+public interface ArticleRepository {
+
+  Article save(Article article);
+
+  Optional<Article> findBySlug(String slug);
+
+  void delete(Article article);
+
+  boolean existsBySlug(String slug);
+}

--- a/backend/src/test/java/com/conduit/article/adapter/in/web/ArticleControllerTest.java
+++ b/backend/src/test/java/com/conduit/article/adapter/in/web/ArticleControllerTest.java
@@ -1,0 +1,289 @@
+package com.conduit.article.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.conduit.shared.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ArticleControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private JwtTokenProvider jwtTokenProvider;
+
+  private String registerAndGetToken(String username, String email, String password)
+      throws Exception {
+    String body =
+        """
+        {"user":{"username":"%s","email":"%s","password":"%s"}}
+        """
+            .formatted(username, email, password);
+
+    MvcResult result =
+        mockMvc
+            .perform(post("/api/users").contentType(MediaType.APPLICATION_JSON).content(body))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return com.jayway.jsonpath.JsonPath.read(
+        result.getResponse().getContentAsString(), "$.user.token");
+  }
+
+  private String createArticle(String token, String title, String desc, String body, String tags)
+      throws Exception {
+    String requestBody =
+        """
+        {"article":{"title":"%s","description":"%s","body":"%s","tagList":[%s]}}
+        """
+            .formatted(title, desc, body, tags);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/articles")
+                    .header("Authorization", "Token " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return com.jayway.jsonpath.JsonPath.read(
+        result.getResponse().getContentAsString(), "$.article.slug");
+  }
+
+  @Nested
+  @DisplayName("POST /api/articles")
+  class CreateArticle {
+
+    @Test
+    @DisplayName("should create article with tags")
+    void success() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc
+          .perform(
+              post("/api/articles")
+                  .header("Authorization", "Token " + token)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"How to train your dragon","description":"Ever wonder how?","body":"It takes a village...","tagList":["dragons","training"]}}
+                      """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.slug").value("how-to-train-your-dragon"))
+          .andExpect(jsonPath("$.article.title").value("How to train your dragon"))
+          .andExpect(jsonPath("$.article.description").value("Ever wonder how?"))
+          .andExpect(jsonPath("$.article.body").value("It takes a village..."))
+          .andExpect(jsonPath("$.article.tagList[0]").value("dragons"))
+          .andExpect(jsonPath("$.article.tagList[1]").value("training"))
+          .andExpect(jsonPath("$.article.favoritesCount").value(0))
+          .andExpect(jsonPath("$.article.author.username").value("jacob"))
+          .andExpect(jsonPath("$.article.createdAt").isNotEmpty())
+          .andExpect(jsonPath("$.article.updatedAt").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("should create article without tags")
+    void withoutTags() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc
+          .perform(
+              post("/api/articles")
+                  .header("Authorization", "Token " + token)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"No Tags Article","description":"Desc","body":"Body"}}
+                      """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.slug").value("no-tags-article"))
+          .andExpect(jsonPath("$.article.tagList").isEmpty());
+    }
+
+    @Test
+    @DisplayName("should return 401 without authentication")
+    void unauthorized() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/articles")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"Test","description":"Desc","body":"Body"}}
+                      """))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should append suffix for duplicate slug")
+    void duplicateSlug() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+
+      createArticle(token, "Same Title", "Desc 1", "Body 1", "");
+
+      mockMvc
+          .perform(
+              post("/api/articles")
+                  .header("Authorization", "Token " + token)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"Same Title","description":"Desc 2","body":"Body 2"}}
+                      """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.slug").value("same-title-1"));
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/articles/{slug}")
+  class GetArticle {
+
+    @Test
+    @DisplayName("should get article by slug without authentication")
+    void success() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "My Article", "Desc", "Body", "\"tag1\"");
+
+      mockMvc
+          .perform(get("/api/articles/" + slug))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.slug").value(slug))
+          .andExpect(jsonPath("$.article.title").value("My Article"))
+          .andExpect(jsonPath("$.article.author.username").value("jacob"));
+    }
+
+    @Test
+    @DisplayName("should return 404 for nonexistent slug")
+    void notFound() throws Exception {
+      mockMvc.perform(get("/api/articles/nonexistent")).andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /api/articles/{slug}")
+  class UpdateArticle {
+
+    @Test
+    @DisplayName("should update article title")
+    void success() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "Old Title", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              put("/api/articles/" + slug)
+                  .header("Authorization", "Token " + token)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"New Title"}}
+                      """))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.title").value("New Title"))
+          .andExpect(jsonPath("$.article.slug").value("new-title"));
+    }
+
+    @Test
+    @DisplayName("should return 403 when non-author tries to update")
+    void forbidden() throws Exception {
+      String authorToken = registerAndGetToken("author", "author@test.com", "password123");
+      String otherToken = registerAndGetToken("other", "other@test.com", "password123");
+      String slug = createArticle(authorToken, "Author Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              put("/api/articles/" + slug)
+                  .header("Authorization", "Token " + otherToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"Hacked Title"}}
+                      """))
+          .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("should return 401 without authentication")
+    void unauthorized() throws Exception {
+      mockMvc
+          .perform(
+              put("/api/articles/some-slug")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      """
+                      {"article":{"title":"New Title"}}
+                      """))
+          .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /api/articles/{slug}")
+  class DeleteArticle {
+
+    @Test
+    @DisplayName("should delete article by author")
+    void success() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "To Delete", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              delete("/api/articles/" + slug).header("Authorization", "Token " + token))
+          .andExpect(status().isNoContent());
+
+      // Verify article is deleted
+      mockMvc.perform(get("/api/articles/" + slug)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("should return 403 when non-author tries to delete")
+    void forbidden() throws Exception {
+      String authorToken = registerAndGetToken("author", "author@test.com", "password123");
+      String otherToken = registerAndGetToken("other", "other@test.com", "password123");
+      String slug = createArticle(authorToken, "Author Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              delete("/api/articles/" + slug).header("Authorization", "Token " + otherToken))
+          .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("should return 401 without authentication")
+    void unauthorized() throws Exception {
+      mockMvc.perform(delete("/api/articles/some-slug")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should return 404 for nonexistent article")
+    void notFound() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc
+          .perform(
+              delete("/api/articles/nonexistent").header("Authorization", "Token " + token))
+          .andExpect(status().isNotFound());
+    }
+  }
+}

--- a/backend/src/test/java/com/conduit/article/application/service/ArticleServiceTest.java
+++ b/backend/src/test/java/com/conduit/article/application/service/ArticleServiceTest.java
@@ -1,0 +1,296 @@
+package com.conduit.article.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.conduit.article.domain.model.Article;
+import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.shared.exception.ApiException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+  @Mock private ArticleRepository articleRepository;
+  private ArticleService articleService;
+
+  @BeforeEach
+  void setUp() {
+    articleService = new ArticleService(articleRepository);
+  }
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+
+    @Test
+    @DisplayName("should create article with unique slug")
+    void success() {
+      when(articleRepository.existsBySlug("how-to-train-your-dragon")).thenReturn(false);
+      when(articleRepository.save(any(Article.class)))
+          .thenAnswer(
+              inv -> {
+                Article a = inv.getArgument(0);
+                return new Article(
+                    1L,
+                    a.getSlug(),
+                    a.getTitle(),
+                    a.getDescription(),
+                    a.getBody(),
+                    a.getAuthorId(),
+                    a.getTagList(),
+                    0,
+                    Instant.now(),
+                    Instant.now());
+              });
+
+      Article result =
+          articleService.create(
+              "How to train your dragon",
+              "Ever wonder how?",
+              "It takes a village...",
+              1L,
+              List.of("dragons", "training"));
+
+      assertThat(result.getId()).isEqualTo(1L);
+      assertThat(result.getSlug()).isEqualTo("how-to-train-your-dragon");
+      assertThat(result.getTitle()).isEqualTo("How to train your dragon");
+      assertThat(result.getTagList()).containsExactly("dragons", "training");
+    }
+
+    @Test
+    @DisplayName("should append suffix when slug is duplicate")
+    void duplicateSlug() {
+      when(articleRepository.existsBySlug("how-to-train-your-dragon")).thenReturn(true);
+      when(articleRepository.existsBySlug("how-to-train-your-dragon-1")).thenReturn(false);
+      when(articleRepository.save(any(Article.class)))
+          .thenAnswer(
+              inv -> {
+                Article a = inv.getArgument(0);
+                return new Article(
+                    1L,
+                    a.getSlug(),
+                    a.getTitle(),
+                    a.getDescription(),
+                    a.getBody(),
+                    a.getAuthorId(),
+                    a.getTagList(),
+                    0,
+                    Instant.now(),
+                    Instant.now());
+              });
+
+      Article result =
+          articleService.create(
+              "How to train your dragon", "Desc", "Body", 1L, List.of());
+
+      assertThat(result.getSlug()).isEqualTo("how-to-train-your-dragon-1");
+    }
+  }
+
+  @Nested
+  @DisplayName("getBySlug")
+  class GetBySlug {
+
+    @Test
+    @DisplayName("should return article when found")
+    void success() {
+      Article article =
+          new Article(
+              1L,
+              "test-slug",
+              "Test Title",
+              "Desc",
+              "Body",
+              1L,
+              List.of(),
+              0,
+              Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+
+      Article result = articleService.getBySlug("test-slug");
+
+      assertThat(result.getSlug()).isEqualTo("test-slug");
+      assertThat(result.getTitle()).isEqualTo("Test Title");
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException when article not found")
+    void notFound() {
+      when(articleRepository.findBySlug("nonexistent")).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> articleService.getBySlug("nonexistent"))
+          .isInstanceOf(ApiException.NotFoundException.class)
+          .hasMessageContaining("article not found");
+    }
+  }
+
+  @Nested
+  @DisplayName("update")
+  class Update {
+
+    @Test
+    @DisplayName("should update article when user is author")
+    void success() {
+      Article existing =
+          new Article(
+              1L,
+              "old-title",
+              "Old Title",
+              "Old Desc",
+              "Old Body",
+              1L,
+              List.of("tag1"),
+              0,
+              Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("old-title")).thenReturn(Optional.of(existing));
+      when(articleRepository.existsBySlug("new-title")).thenReturn(false);
+      when(articleRepository.save(any(Article.class)))
+          .thenAnswer(inv -> inv.getArgument(0));
+
+      Article result =
+          articleService.update("old-title", 1L, "New Title", "New Desc", "New Body");
+
+      assertThat(result.getTitle()).isEqualTo("New Title");
+      assertThat(result.getSlug()).isEqualTo("new-title");
+      assertThat(result.getDescription()).isEqualTo("New Desc");
+      assertThat(result.getBody()).isEqualTo("New Body");
+    }
+
+    @Test
+    @DisplayName("should throw ForbiddenException when user is not author")
+    void forbidden() {
+      Article existing =
+          new Article(
+              1L,
+              "test-slug",
+              "Title",
+              "Desc",
+              "Body",
+              1L,
+              List.of(),
+              0,
+              Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(existing));
+
+      assertThatThrownBy(
+              () -> articleService.update("test-slug", 999L, "New Title", null, null))
+          .isInstanceOf(ApiException.ForbiddenException.class)
+          .hasMessageContaining("you are not the author");
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException when article not found")
+    void notFound() {
+      when(articleRepository.findBySlug("nonexistent")).thenReturn(Optional.empty());
+
+      assertThatThrownBy(
+              () -> articleService.update("nonexistent", 1L, "New Title", null, null))
+          .isInstanceOf(ApiException.NotFoundException.class)
+          .hasMessageContaining("article not found");
+    }
+
+    @Test
+    @DisplayName("should update only description without changing slug")
+    void updateDescriptionOnly() {
+      Article existing =
+          new Article(
+              1L,
+              "my-title",
+              "My Title",
+              "Old Desc",
+              "Body",
+              1L,
+              List.of(),
+              0,
+              Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("my-title")).thenReturn(Optional.of(existing));
+      when(articleRepository.save(any(Article.class)))
+          .thenAnswer(inv -> inv.getArgument(0));
+
+      Article result = articleService.update("my-title", 1L, null, "New Desc", null);
+
+      assertThat(result.getSlug()).isEqualTo("my-title");
+      assertThat(result.getDescription()).isEqualTo("New Desc");
+    }
+  }
+
+  @Nested
+  @DisplayName("delete")
+  class Delete {
+
+    @Test
+    @DisplayName("should delete article when user is author")
+    void success() {
+      Article existing =
+          new Article(
+              1L,
+              "test-slug",
+              "Title",
+              "Desc",
+              "Body",
+              1L,
+              List.of(),
+              0,
+              Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(existing));
+
+      articleService.delete("test-slug", 1L);
+
+      verify(articleRepository).delete(existing);
+    }
+
+    @Test
+    @DisplayName("should throw ForbiddenException when user is not author")
+    void forbidden() {
+      Article existing =
+          new Article(
+              1L,
+              "test-slug",
+              "Title",
+              "Desc",
+              "Body",
+              1L,
+              List.of(),
+              0,
+              Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(existing));
+
+      assertThatThrownBy(() -> articleService.delete("test-slug", 999L))
+          .isInstanceOf(ApiException.ForbiddenException.class)
+          .hasMessageContaining("you are not the author");
+
+      verify(articleRepository, never()).delete(any(Article.class));
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException when article not found")
+    void notFound() {
+      when(articleRepository.findBySlug("nonexistent")).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> articleService.delete("nonexistent", 1L))
+          .isInstanceOf(ApiException.NotFoundException.class)
+          .hasMessageContaining("article not found");
+    }
+  }
+}

--- a/backend/src/test/java/com/conduit/article/domain/model/ArticleTest.java
+++ b/backend/src/test/java/com/conduit/article/domain/model/ArticleTest.java
@@ -1,0 +1,144 @@
+package com.conduit.article.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ArticleTest {
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+
+    @Test
+    @DisplayName("should create article with generated slug")
+    void success() {
+      Article article =
+          Article.create("How to train your dragon", "Ever wonder how?", "It takes a village...",
+              1L, List.of("dragons", "training"));
+
+      assertThat(article.getId()).isNull();
+      assertThat(article.getSlug()).isEqualTo("how-to-train-your-dragon");
+      assertThat(article.getTitle()).isEqualTo("How to train your dragon");
+      assertThat(article.getDescription()).isEqualTo("Ever wonder how?");
+      assertThat(article.getBody()).isEqualTo("It takes a village...");
+      assertThat(article.getAuthorId()).isEqualTo(1L);
+      assertThat(article.getTagList()).containsExactly("dragons", "training");
+      assertThat(article.getFavoritesCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("should create article with empty tag list when null")
+    void nullTagList() {
+      Article article = Article.create("Title", "Desc", "Body", 1L, null);
+
+      assertThat(article.getTagList()).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("generateSlug")
+  class GenerateSlug {
+
+    @Test
+    @DisplayName("should lowercase and replace non-alphanumeric with hyphens")
+    void basicSlug() {
+      assertThat(Article.generateSlug("How to Train Your Dragon"))
+          .isEqualTo("how-to-train-your-dragon");
+    }
+
+    @Test
+    @DisplayName("should trim leading and trailing hyphens")
+    void trimHyphens() {
+      assertThat(Article.generateSlug("  --Hello World--  ")).isEqualTo("hello-world");
+    }
+
+    @Test
+    @DisplayName("should handle special characters")
+    void specialChars() {
+      assertThat(Article.generateSlug("What's up? 100% awesome!"))
+          .isEqualTo("what-s-up-100-awesome");
+    }
+
+    @Test
+    @DisplayName("should truncate to max 100 chars")
+    void maxLength() {
+      String longTitle = "a".repeat(200);
+      String slug = Article.generateSlug(longTitle);
+      assertThat(slug.length()).isLessThanOrEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("should return empty for blank title")
+    void blankTitle() {
+      assertThat(Article.generateSlug("")).isEmpty();
+      assertThat(Article.generateSlug("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return empty for null title")
+    void nullTitle() {
+      assertThat(Article.generateSlug(null)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("update")
+  class Update {
+
+    @Test
+    @DisplayName("should update title and regenerate slug")
+    void updateTitle() {
+      Article article =
+          Article.create("Old Title", "Desc", "Body", 1L, List.of());
+
+      article.update("New Title", null, null);
+
+      assertThat(article.getTitle()).isEqualTo("New Title");
+      assertThat(article.getSlug()).isEqualTo("new-title");
+      assertThat(article.getDescription()).isEqualTo("Desc");
+      assertThat(article.getBody()).isEqualTo("Body");
+    }
+
+    @Test
+    @DisplayName("should update description only")
+    void updateDescription() {
+      Article article =
+          Article.create("Title", "Old Desc", "Body", 1L, List.of());
+
+      article.update(null, "New Desc", null);
+
+      assertThat(article.getTitle()).isEqualTo("Title");
+      assertThat(article.getSlug()).isEqualTo("title");
+      assertThat(article.getDescription()).isEqualTo("New Desc");
+    }
+
+    @Test
+    @DisplayName("should update body only")
+    void updateBody() {
+      Article article =
+          Article.create("Title", "Desc", "Old Body", 1L, List.of());
+
+      article.update(null, null, "New Body");
+
+      assertThat(article.getBody()).isEqualTo("New Body");
+    }
+
+    @Test
+    @DisplayName("should update all fields")
+    void updateAll() {
+      Article article =
+          Article.create("Old Title", "Old Desc", "Old Body", 1L, List.of());
+
+      article.update("New Title", "New Desc", "New Body");
+
+      assertThat(article.getTitle()).isEqualTo("New Title");
+      assertThat(article.getSlug()).isEqualTo("new-title");
+      assertThat(article.getDescription()).isEqualTo("New Desc");
+      assertThat(article.getBody()).isEqualTo("New Body");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Hexagonal Architecture 패턴으로 Article 도메인 전체 구현 (Domain → Port → Service → Adapter)
- POST/GET/PUT/DELETE `/api/articles` 엔드포인트 — RealWorld API 스펙 준수
- Slug 자동생성 (title → lowercase kebab) + 중복 시 `-N` suffix dedup
- 작성자 검증: 수정/삭제 시 `authorId == userId` 체크, 불일치 시 403 Forbidden
- 태그 find-or-create 패턴 — `article_tags` 다대다 매핑

## Test Plan

### 1. 단위 테스트 (36 cases)
- [x] `ArticleTest` (12): 도메인 모델 생성, slug 생성, update partial fields
- [x] `ArticleServiceTest` (11): CRUD 비즈니스 로직, slug dedup, 작성자 검증, 404/403
- [x] `ArticleControllerTest` (13): MockMvc 엔드포인트 검증, 요청/응답 직렬화

### 2. 통합 테스트
- [x] `./gradlew test` BUILD SUCCESSFUL — 전체 테스트 스위트 통과 (H2 PostgreSQL 호환 모드)

### 3. 보안 검증
- [x] POST/PUT/DELETE: JWT 인증 필수 (SecurityConfig)
- [x] GET /api/articles/{slug}: 공개 접근 허용
- [x] 작성자 외 수정/삭제 시 ForbiddenException → 403

### 4. 부팅 검증
- [x] `./gradlew bootRun --args='--spring.profiles.active=local'` — H2 정상 부팅
- [x] `./gradlew bootRun --args='--spring.profiles.active=test'` — 테스트 프로파일 정상

Closes #11

**Touched Areas**: `article/` 전체 (신규 모듈)

**Flow Mode**: add | Issue #11 auto-detected as `type:feature` + new behavior → mode=add