### PR TITLE
feat(backend): Tag 모듈 — 태그 목록 조회 + 아티클-태그 연관

### DIFF
--- a/backend/src/main/java/com/conduit/tag/adapter/in/web/TagController.java
+++ b/backend/src/main/java/com/conduit/tag/adapter/in/web/TagController.java
@@ -1,0 +1,26 @@
+package com.conduit.tag.adapter.in.web;
+
+import com.conduit.tag.domain.port.in.GetTagsUseCase;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TagController {
+
+  private final GetTagsUseCase getTagsUseCase;
+
+  public TagController(GetTagsUseCase getTagsUseCase) {
+    this.getTagsUseCase = getTagsUseCase;
+  }
+
+  @GetMapping("/tags")
+  public ResponseEntity<Map<String, List<String>>> getTags() {
+    List<String> tags = getTagsUseCase.getAllTagNames();
+    return ResponseEntity.ok(Map.of("tags", tags));
+  }
+}

--- a/backend/src/main/java/com/conduit/tag/adapter/out/persistence/TagPersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/tag/adapter/out/persistence/TagPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.conduit.tag.adapter.out.persistence;
+
+import com.conduit.article.adapter.out.persistence.TagJpaEntity;
+import com.conduit.article.adapter.out.persistence.TagJpaRepository;
+import com.conduit.tag.domain.model.Tag;
+import com.conduit.tag.domain.port.out.TagRepository;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TagPersistenceAdapter implements TagRepository {
+
+  private final TagJpaRepository tagJpaRepository;
+
+  public TagPersistenceAdapter(TagJpaRepository tagJpaRepository) {
+    this.tagJpaRepository = tagJpaRepository;
+  }
+
+  @Override
+  public List<Tag> findAll() {
+    return tagJpaRepository.findAll().stream()
+        .map(entity -> new Tag(entity.getId(), entity.getName()))
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/conduit/tag/application/service/TagService.java
+++ b/backend/src/main/java/com/conduit/tag/application/service/TagService.java
@@ -1,0 +1,24 @@
+package com.conduit.tag.application.service;
+
+import com.conduit.tag.domain.model.Tag;
+import com.conduit.tag.domain.port.in.GetTagsUseCase;
+import com.conduit.tag.domain.port.out.TagRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TagService implements GetTagsUseCase {
+
+  private final TagRepository tagRepository;
+
+  public TagService(TagRepository tagRepository) {
+    this.tagRepository = tagRepository;
+  }
+
+  @Override
+  public List<String> getAllTagNames() {
+    return tagRepository.findAll().stream().map(Tag::getName).sorted().toList();
+  }
+}

--- a/backend/src/main/java/com/conduit/tag/domain/model/Tag.java
+++ b/backend/src/main/java/com/conduit/tag/domain/model/Tag.java
@@ -1,0 +1,20 @@
+package com.conduit.tag.domain.model;
+
+public class Tag {
+
+  private final Long id;
+  private final String name;
+
+  public Tag(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/backend/src/main/java/com/conduit/tag/domain/port/in/GetTagsUseCase.java
+++ b/backend/src/main/java/com/conduit/tag/domain/port/in/GetTagsUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.tag.domain.port.in;
+
+import java.util.List;
+
+public interface GetTagsUseCase {
+
+  List<String> getAllTagNames();
+}

--- a/backend/src/main/java/com/conduit/tag/domain/port/out/TagRepository.java
+++ b/backend/src/main/java/com/conduit/tag/domain/port/out/TagRepository.java
@@ -1,0 +1,9 @@
+package com.conduit.tag.domain.port.out;
+
+import com.conduit.tag.domain.model.Tag;
+import java.util.List;
+
+public interface TagRepository {
+
+  List<Tag> findAll();
+}

--- a/backend/src/test/java/com/conduit/tag/adapter/in/web/TagControllerTest.java
+++ b/backend/src/test/java/com/conduit/tag/adapter/in/web/TagControllerTest.java
@@ -1,0 +1,51 @@
+package com.conduit.tag.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("TagController Tests")
+class TagControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("GET /api/tags should return 200 with tags array")
+  void getTags() throws Exception {
+    mockMvc
+        .perform(get("/api/tags"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.tags").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/tags should be accessible without authentication")
+  void getTagsPublic() throws Exception {
+    mockMvc.perform(get("/api/tags")).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET /api/tags response should have correct content type")
+  void contentType() throws Exception {
+    mockMvc
+        .perform(get("/api/tags"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+  }
+}

--- a/backend/src/test/java/com/conduit/tag/adapter/in/web/TagIntegrationTest.java
+++ b/backend/src/test/java/com/conduit/tag/adapter/in/web/TagIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.conduit.tag.adapter.in.web;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Tag Integration Tests")
+class TagIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("GET /api/tags should return empty array when no articles with tags")
+  void emptyTags() throws Exception {
+    mockMvc
+        .perform(get("/api/tags"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tags").isArray())
+        .andExpect(jsonPath("$.tags", hasSize(0)));
+  }
+
+  @Test
+  @DisplayName("GET /api/tags should return tags from created articles")
+  void tagsFromArticles() throws Exception {
+    String token = registerAndGetToken("taguser", "tag@test.com", "password123");
+
+    // Create article with tags
+    mockMvc
+        .perform(
+            post("/api/articles")
+                .header("Authorization", "Token " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+            {"article":{"title":"Test Article","description":"desc","body":"body","tagList":["java","spring"]}}
+            """))
+        .andExpect(status().isOk());
+
+    // GET /api/tags should include the tags
+    mockMvc
+        .perform(get("/api/tags"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tags").isArray())
+        .andExpect(jsonPath("$.tags", hasSize(2)))
+        .andExpect(jsonPath("$.tags", hasItem("java")))
+        .andExpect(jsonPath("$.tags", hasItem("spring")));
+  }
+
+  @Test
+  @DisplayName("tags should be deduplicated across articles")
+  void deduplicatedTags() throws Exception {
+    String token = registerAndGetToken("taguser2", "tag2@test.com", "password123");
+
+    // Create two articles with overlapping tags
+    mockMvc
+        .perform(
+            post("/api/articles")
+                .header("Authorization", "Token " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+            {"article":{"title":"Article 1","description":"desc","body":"body","tagList":["java","spring"]}}
+            """))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            post("/api/articles")
+                .header("Authorization", "Token " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+            {"article":{"title":"Article 2","description":"desc","body":"body","tagList":["java","react"]}}
+            """))
+        .andExpect(status().isOk());
+
+    // Should return 3 unique tags, not 4
+    mockMvc
+        .perform(get("/api/tags"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.tags", hasSize(3)))
+        .andExpect(jsonPath("$.tags", hasItem("java")))
+        .andExpect(jsonPath("$.tags", hasItem("spring")))
+        .andExpect(jsonPath("$.tags", hasItem("react")));
+  }
+
+  @Test
+  @DisplayName("GET /api/tags should not require authentication")
+  void publicAccess() throws Exception {
+    mockMvc.perform(get("/api/tags")).andExpect(status().isOk());
+  }
+
+  private String registerAndGetToken(String username, String email, String password)
+      throws Exception {
+    String body =
+        """
+        {"user":{"username":"%s","email":"%s","password":"%s"}}
+        """
+            .formatted(username, email, password);
+
+    MvcResult result =
+        mockMvc
+            .perform(post("/api/users").contentType(MediaType.APPLICATION_JSON).content(body))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return JsonPath.read(result.getResponse().getContentAsString(), "$.user.token");
+  }
+}

--- a/backend/src/test/java/com/conduit/tag/application/service/TagServiceTest.java
+++ b/backend/src/test/java/com/conduit/tag/application/service/TagServiceTest.java
@@ -1,0 +1,74 @@
+package com.conduit.tag.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.conduit.tag.domain.model.Tag;
+import com.conduit.tag.domain.port.out.TagRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TagService Unit Tests")
+class TagServiceTest {
+
+  private TagService tagService;
+  private StubTagRepository stubTagRepository;
+
+  @BeforeEach
+  void setUp() {
+    stubTagRepository = new StubTagRepository();
+    tagService = new TagService(stubTagRepository);
+  }
+
+  @Test
+  @DisplayName("should return empty list when no tags exist")
+  void emptyTags() {
+    stubTagRepository.tags = List.of();
+
+    List<String> result = tagService.getAllTagNames();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("should return all tag names")
+  void allTagNames() {
+    stubTagRepository.tags =
+        List.of(new Tag(1L, "java"), new Tag(2L, "spring"), new Tag(3L, "react"));
+
+    List<String> result = tagService.getAllTagNames();
+
+    assertThat(result).containsExactly("java", "react", "spring");
+  }
+
+  @Test
+  @DisplayName("should return tag names sorted alphabetically")
+  void sortedAlphabetically() {
+    stubTagRepository.tags =
+        List.of(new Tag(1L, "zebra"), new Tag(2L, "alpha"), new Tag(3L, "middle"));
+
+    List<String> result = tagService.getAllTagNames();
+
+    assertThat(result).containsExactly("alpha", "middle", "zebra");
+  }
+
+  @Test
+  @DisplayName("should return single tag")
+  void singleTag() {
+    stubTagRepository.tags = List.of(new Tag(1L, "solo"));
+
+    List<String> result = tagService.getAllTagNames();
+
+    assertThat(result).containsExactly("solo");
+  }
+
+  static class StubTagRepository implements TagRepository {
+    List<Tag> tags = List.of();
+
+    @Override
+    public List<Tag> findAll() {
+      return tags;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Hexagonal Architecture로 Tag 도메인 구현 — `GET /api/tags` 엔드포인트
- 기존 Article 모듈의 `TagJpaEntity`/`TagJpaRepository`를 재사용하는 `TagPersistenceAdapter`
- 태그 목록 알파벳 정렬 반환, 아티클 간 태그 자동 중복제거 (find-or-create 패턴, #11에서 구현)

## Test Plan

### 1. 단위 테스트 (4 cases)
- [x] `TagServiceTest`: empty, all names, sorted, single tag

### 2. 컨트롤러 테스트 (3 cases)
- [x] `TagControllerTest`: 200 + tags array, public access, content-type

### 3. 통합 테스트 (4 cases)
- [x] `TagIntegrationTest`: empty tags, tags from articles, dedup across articles, public access

### 4. 부팅 검증
- [x] `./gradlew bootRun --args='--spring.profiles.active=local'` — 정상 부팅
- [x] `./gradlew test` BUILD SUCCESSFUL

Closes #12

**Touched Areas**: `tag/` (신규 모듈), `article/` (TagJpaRepository 재사용)

**Flow Mode**: add | Issue #12 auto-detected as `type:feature` + new behavior → mode=add