### PR TITLE
feat(backend): Article 목록/피드 조회 — 필터 + 페이지네이션

### DIFF
--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
@@ -3,13 +3,22 @@ package com.conduit.article.adapter.in.web;
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.in.CreateArticleUseCase;
 import com.conduit.article.domain.port.in.DeleteArticleUseCase;
+import com.conduit.article.domain.port.in.FeedArticlesUseCase;
 import com.conduit.article.domain.port.in.GetArticleUseCase;
+import com.conduit.article.domain.port.in.ListArticlesUseCase;
 import com.conduit.article.domain.port.in.UpdateArticleUseCase;
+import com.conduit.article.domain.port.out.FavoriteRepository;
+import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import com.conduit.user.domain.model.User;
 import com.conduit.user.domain.port.out.UserRepository;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +28,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,19 +39,31 @@ public class ArticleController {
   private final GetArticleUseCase getArticleUseCase;
   private final UpdateArticleUseCase updateArticleUseCase;
   private final DeleteArticleUseCase deleteArticleUseCase;
+  private final ListArticlesUseCase listArticlesUseCase;
+  private final FeedArticlesUseCase feedArticlesUseCase;
   private final UserRepository userRepository;
+  private final FavoriteRepository favoriteRepository;
+  private final FollowRepository followRepository;
 
   public ArticleController(
       CreateArticleUseCase createArticleUseCase,
       GetArticleUseCase getArticleUseCase,
       UpdateArticleUseCase updateArticleUseCase,
       DeleteArticleUseCase deleteArticleUseCase,
-      UserRepository userRepository) {
+      ListArticlesUseCase listArticlesUseCase,
+      FeedArticlesUseCase feedArticlesUseCase,
+      UserRepository userRepository,
+      FavoriteRepository favoriteRepository,
+      FollowRepository followRepository) {
     this.createArticleUseCase = createArticleUseCase;
     this.getArticleUseCase = getArticleUseCase;
     this.updateArticleUseCase = updateArticleUseCase;
     this.deleteArticleUseCase = deleteArticleUseCase;
+    this.listArticlesUseCase = listArticlesUseCase;
+    this.feedArticlesUseCase = feedArticlesUseCase;
     this.userRepository = userRepository;
+    this.favoriteRepository = favoriteRepository;
+    this.followRepository = followRepository;
   }
 
   @PostMapping("/articles")
@@ -55,6 +77,39 @@ public class ArticleController {
             req.title(), req.description(), req.body(), userId, req.tagList());
     User author = findAuthor(article.getAuthorId());
     return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
+  }
+
+  @GetMapping("/articles")
+  public ResponseEntity<Map<String, Object>> listArticles(
+      Authentication authentication,
+      @RequestParam(required = false) String tag,
+      @RequestParam(required = false) String author,
+      @RequestParam(required = false) String favorited,
+      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(defaultValue = "0") int offset) {
+    List<Article> articles =
+        listArticlesUseCase.listArticles(tag, author, favorited, limit, offset);
+    long articlesCount = listArticlesUseCase.countArticles(tag, author, favorited);
+
+    Long currentUserId = getCurrentUserId(authentication);
+    List<ArticleResponse> responses = buildArticleResponses(articles, currentUserId);
+
+    return ResponseEntity.ok(Map.of("articles", responses, "articlesCount", articlesCount));
+  }
+
+  @GetMapping("/articles/feed")
+  public ResponseEntity<Map<String, Object>> feedArticles(
+      Authentication authentication,
+      @RequestParam(defaultValue = "20") int limit,
+      @RequestParam(defaultValue = "0") int offset) {
+    Long userId = (Long) authentication.getPrincipal();
+
+    List<Article> articles = feedArticlesUseCase.feedArticles(userId, limit, offset);
+    long articlesCount = feedArticlesUseCase.countFeedArticles(userId);
+
+    List<ArticleResponse> responses = buildArticleResponses(articles, userId);
+
+    return ResponseEntity.ok(Map.of("articles", responses, "articlesCount", articlesCount));
   }
 
   @GetMapping("/articles/{slug}")
@@ -83,6 +138,50 @@ public class ArticleController {
     Long userId = (Long) authentication.getPrincipal();
     deleteArticleUseCase.delete(slug, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  private List<ArticleResponse> buildArticleResponses(List<Article> articles, Long currentUserId) {
+    if (articles.isEmpty()) {
+      return List.of();
+    }
+
+    List<Long> articleIds = articles.stream().map(Article::getId).toList();
+    List<Long> authorIds = articles.stream().map(Article::getAuthorId).distinct().toList();
+
+    Set<Long> favoritedArticleIds =
+        currentUserId != null
+            ? favoriteRepository.findFavoritedArticleIds(currentUserId, articleIds)
+            : Set.of();
+
+    Set<Long> followedAuthorIds =
+        currentUserId != null
+            ? followRepository.findFollowedUserIds(currentUserId, authorIds)
+            : Set.of();
+
+    Map<Long, User> authorMap =
+        authorIds.stream()
+            .map(id -> userRepository.findById(id).orElse(null))
+            .filter(user -> user != null)
+            .collect(Collectors.toMap(User::getId, Function.identity()));
+
+    List<ArticleResponse> responses = new ArrayList<>();
+    for (Article article : articles) {
+      User author = authorMap.get(article.getAuthorId());
+      if (author == null) {
+        continue;
+      }
+      boolean isFavorited = favoritedArticleIds.contains(article.getId());
+      boolean isFollowing = followedAuthorIds.contains(article.getAuthorId());
+      responses.add(ArticleResponse.from(article, author, isFavorited, isFollowing));
+    }
+    return responses;
+  }
+
+  private Long getCurrentUserId(Authentication authentication) {
+    if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
+      return userId;
+    }
+    return null;
   }
 
   private User findAuthor(Long authorId) {

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleResponse.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleResponse.java
@@ -13,10 +13,16 @@ public record ArticleResponse(
     List<String> tagList,
     Instant createdAt,
     Instant updatedAt,
+    boolean favorited,
     int favoritesCount,
     AuthorResponse author) {
 
   public static ArticleResponse from(Article article, User author) {
+    return from(article, author, false, false);
+  }
+
+  public static ArticleResponse from(
+      Article article, User author, boolean favorited, boolean following) {
     return new ArticleResponse(
         article.getSlug(),
         article.getTitle(),
@@ -25,9 +31,10 @@ public record ArticleResponse(
         article.getTagList(),
         article.getCreatedAt(),
         article.getUpdatedAt(),
+        favorited,
         article.getFavoritesCount(),
-        new AuthorResponse(author.getUsername(), author.getBio(), author.getImage()));
+        new AuthorResponse(author.getUsername(), author.getBio(), author.getImage(), following));
   }
 
-  public record AuthorResponse(String username, String bio, String image) {}
+  public record AuthorResponse(String username, String bio, String image, boolean following) {}
 }

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticlePersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/ArticlePersistenceAdapter.java
@@ -2,6 +2,9 @@ package com.conduit.article.adapter.out.persistence;
 
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.out.ArticleRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +15,8 @@ public class ArticlePersistenceAdapter implements ArticleRepository {
 
   private final ArticleJpaRepository articleJpaRepository;
   private final TagJpaRepository tagJpaRepository;
+
+  @PersistenceContext private EntityManager entityManager;
 
   public ArticlePersistenceAdapter(
       ArticleJpaRepository articleJpaRepository, TagJpaRepository tagJpaRepository) {
@@ -57,14 +62,136 @@ public class ArticlePersistenceAdapter implements ArticleRepository {
 
   @Override
   public void delete(Article article) {
-    articleJpaRepository
-        .findById(article.getId())
-        .ifPresent(articleJpaRepository::delete);
+    articleJpaRepository.findById(article.getId()).ifPresent(articleJpaRepository::delete);
   }
 
   @Override
   public boolean existsBySlug(String slug) {
     return articleJpaRepository.existsBySlug(slug);
+  }
+
+  @Override
+  public List<Article> findAll(
+      String tag, String authorUsername, String favoritedByUsername, int limit, int offset) {
+    StringBuilder jpql = new StringBuilder("SELECT DISTINCT a FROM ArticleJpaEntity a");
+    List<String> joins = new ArrayList<>();
+    List<String> conditions = new ArrayList<>();
+
+    if (tag != null && !tag.isBlank()) {
+      joins.add("JOIN a.tags t");
+      conditions.add("t.name = :tag");
+    }
+    if (authorUsername != null && !authorUsername.isBlank()) {
+      joins.add(
+          "JOIN com.conduit.user.adapter.out.persistence.UserJpaEntity u ON a.authorId = u.id");
+      conditions.add("u.username = :authorUsername");
+    }
+    if (favoritedByUsername != null && !favoritedByUsername.isBlank()) {
+      joins.add(
+          "JOIN com.conduit.user.adapter.out.persistence.UserJpaEntity fu ON fu.username = :favoritedByUsername");
+      joins.add(
+          "JOIN FavoriteJpaEntity fav ON fav.articleId = a.id AND fav.userId = fu.id");
+    }
+
+    for (String join : joins) {
+      jpql.append(" ").append(join);
+    }
+
+    if (!conditions.isEmpty()) {
+      jpql.append(" WHERE ").append(String.join(" AND ", conditions));
+    }
+
+    jpql.append(" ORDER BY a.createdAt DESC");
+
+    TypedQuery<ArticleJpaEntity> query =
+        entityManager.createQuery(jpql.toString(), ArticleJpaEntity.class);
+
+    if (tag != null && !tag.isBlank()) {
+      query.setParameter("tag", tag);
+    }
+    if (authorUsername != null && !authorUsername.isBlank()) {
+      query.setParameter("authorUsername", authorUsername);
+    }
+    if (favoritedByUsername != null && !favoritedByUsername.isBlank()) {
+      query.setParameter("favoritedByUsername", favoritedByUsername);
+    }
+
+    query.setFirstResult(offset);
+    query.setMaxResults(limit);
+
+    return query.getResultList().stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public long countAll(String tag, String authorUsername, String favoritedByUsername) {
+    StringBuilder jpql = new StringBuilder("SELECT COUNT(DISTINCT a.id) FROM ArticleJpaEntity a");
+    List<String> joins = new ArrayList<>();
+    List<String> conditions = new ArrayList<>();
+
+    if (tag != null && !tag.isBlank()) {
+      joins.add("JOIN a.tags t");
+      conditions.add("t.name = :tag");
+    }
+    if (authorUsername != null && !authorUsername.isBlank()) {
+      joins.add(
+          "JOIN com.conduit.user.adapter.out.persistence.UserJpaEntity u ON a.authorId = u.id");
+      conditions.add("u.username = :authorUsername");
+    }
+    if (favoritedByUsername != null && !favoritedByUsername.isBlank()) {
+      joins.add(
+          "JOIN com.conduit.user.adapter.out.persistence.UserJpaEntity fu ON fu.username = :favoritedByUsername");
+      joins.add(
+          "JOIN FavoriteJpaEntity fav ON fav.articleId = a.id AND fav.userId = fu.id");
+    }
+
+    for (String join : joins) {
+      jpql.append(" ").append(join);
+    }
+
+    if (!conditions.isEmpty()) {
+      jpql.append(" WHERE ").append(String.join(" AND ", conditions));
+    }
+
+    TypedQuery<Long> query = entityManager.createQuery(jpql.toString(), Long.class);
+
+    if (tag != null && !tag.isBlank()) {
+      query.setParameter("tag", tag);
+    }
+    if (authorUsername != null && !authorUsername.isBlank()) {
+      query.setParameter("authorUsername", authorUsername);
+    }
+    if (favoritedByUsername != null && !favoritedByUsername.isBlank()) {
+      query.setParameter("favoritedByUsername", favoritedByUsername);
+    }
+
+    return query.getSingleResult();
+  }
+
+  @Override
+  public List<Article> findByAuthorIds(List<Long> authorIds, int limit, int offset) {
+    if (authorIds == null || authorIds.isEmpty()) {
+      return List.of();
+    }
+    TypedQuery<ArticleJpaEntity> query =
+        entityManager.createQuery(
+            "SELECT a FROM ArticleJpaEntity a WHERE a.authorId IN :authorIds ORDER BY a.createdAt DESC",
+            ArticleJpaEntity.class);
+    query.setParameter("authorIds", authorIds);
+    query.setFirstResult(offset);
+    query.setMaxResults(limit);
+    return query.getResultList().stream().map(this::toDomain).toList();
+  }
+
+  @Override
+  public long countByAuthorIds(List<Long> authorIds) {
+    if (authorIds == null || authorIds.isEmpty()) {
+      return 0;
+    }
+    TypedQuery<Long> query =
+        entityManager.createQuery(
+            "SELECT COUNT(a) FROM ArticleJpaEntity a WHERE a.authorId IN :authorIds", Long.class);
+    query.setParameter("authorIds", authorIds);
+    return query.getSingleResult();
   }
 
   private List<TagJpaEntity> resolveTagEntities(List<String> tagNames) {
@@ -77,8 +204,7 @@ public class ArticlePersistenceAdapter implements ArticleRepository {
       TagJpaEntity tagEntity =
           tagJpaRepository
               .findByName(tagName)
-              .orElseGet(
-                  () -> tagJpaRepository.save(new TagJpaEntity(tagName)));
+              .orElseGet(() -> tagJpaRepository.save(new TagJpaEntity(tagName)));
       result.add(tagEntity);
     }
     return result;

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteId.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteId.java
@@ -1,0 +1,38 @@
+package com.conduit.article.adapter.out.persistence;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class FavoriteId implements Serializable {
+
+  private Long userId;
+  private Long articleId;
+
+  public FavoriteId() {}
+
+  public FavoriteId(Long userId, Long articleId) {
+    this.userId = userId;
+    this.articleId = articleId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getArticleId() {
+    return articleId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FavoriteId that = (FavoriteId) o;
+    return Objects.equals(userId, that.userId) && Objects.equals(articleId, that.articleId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userId, articleId);
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteJpaEntity.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteJpaEntity.java
@@ -1,0 +1,45 @@
+package com.conduit.article.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "favorites")
+@IdClass(FavoriteId.class)
+public class FavoriteJpaEntity {
+
+  @Id
+  @Column(name = "user_id")
+  private Long userId;
+
+  @Id
+  @Column(name = "article_id")
+  private Long articleId;
+
+  @Column(name = "created_at")
+  private Instant createdAt;
+
+  protected FavoriteJpaEntity() {}
+
+  public FavoriteJpaEntity(Long userId, Long articleId) {
+    this.userId = userId;
+    this.articleId = articleId;
+    this.createdAt = Instant.now();
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getArticleId() {
+    return articleId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteJpaRepository.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteJpaRepository.java
@@ -1,0 +1,15 @@
+package com.conduit.article.adapter.out.persistence;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FavoriteJpaRepository extends JpaRepository<FavoriteJpaEntity, FavoriteId> {
+
+  boolean existsByUserIdAndArticleId(Long userId, Long articleId);
+
+  @Query("SELECT f.articleId FROM FavoriteJpaEntity f WHERE f.userId = :userId AND f.articleId IN :articleIds")
+  List<Long> findArticleIdsByUserIdAndArticleIdIn(
+      @Param("userId") Long userId, @Param("articleIds") List<Long> articleIds);
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoritePersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoritePersistenceAdapter.java
@@ -1,0 +1,31 @@
+package com.conduit.article.adapter.out.persistence;
+
+import com.conduit.article.domain.port.out.FavoriteRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FavoritePersistenceAdapter implements FavoriteRepository {
+
+  private final FavoriteJpaRepository favoriteJpaRepository;
+
+  public FavoritePersistenceAdapter(FavoriteJpaRepository favoriteJpaRepository) {
+    this.favoriteJpaRepository = favoriteJpaRepository;
+  }
+
+  @Override
+  public boolean existsByUserIdAndArticleId(Long userId, Long articleId) {
+    return favoriteJpaRepository.existsByUserIdAndArticleId(userId, articleId);
+  }
+
+  @Override
+  public Set<Long> findFavoritedArticleIds(Long userId, List<Long> articleIds) {
+    if (articleIds == null || articleIds.isEmpty()) {
+      return Set.of();
+    }
+    return new HashSet<>(
+        favoriteJpaRepository.findArticleIdsByUserIdAndArticleIdIn(userId, articleIds));
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowId.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowId.java
@@ -1,0 +1,39 @@
+package com.conduit.article.adapter.out.persistence;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class FollowId implements Serializable {
+
+  private Long followerId;
+  private Long followeeId;
+
+  public FollowId() {}
+
+  public FollowId(Long followerId, Long followeeId) {
+    this.followerId = followerId;
+    this.followeeId = followeeId;
+  }
+
+  public Long getFollowerId() {
+    return followerId;
+  }
+
+  public Long getFolloweeId() {
+    return followeeId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FollowId that = (FollowId) o;
+    return Objects.equals(followerId, that.followerId)
+        && Objects.equals(followeeId, that.followeeId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(followerId, followeeId);
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowJpaEntity.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowJpaEntity.java
@@ -1,0 +1,45 @@
+package com.conduit.article.adapter.out.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "follows")
+@IdClass(FollowId.class)
+public class FollowJpaEntity {
+
+  @Id
+  @Column(name = "follower_id")
+  private Long followerId;
+
+  @Id
+  @Column(name = "followee_id")
+  private Long followeeId;
+
+  @Column(name = "created_at")
+  private Instant createdAt;
+
+  protected FollowJpaEntity() {}
+
+  public FollowJpaEntity(Long followerId, Long followeeId) {
+    this.followerId = followerId;
+    this.followeeId = followeeId;
+    this.createdAt = Instant.now();
+  }
+
+  public Long getFollowerId() {
+    return followerId;
+  }
+
+  public Long getFolloweeId() {
+    return followeeId;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowJpaRepository.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowJpaRepository.java
@@ -1,0 +1,18 @@
+package com.conduit.article.adapter.out.persistence;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FollowJpaRepository extends JpaRepository<FollowJpaEntity, FollowId> {
+
+  boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+
+  @Query("SELECT f.followeeId FROM FollowJpaEntity f WHERE f.followerId = :followerId AND f.followeeId IN :followeeIds")
+  List<Long> findFolloweeIdsByFollowerIdAndFolloweeIdIn(
+      @Param("followerId") Long followerId, @Param("followeeIds") List<Long> followeeIds);
+
+  @Query("SELECT f.followeeId FROM FollowJpaEntity f WHERE f.followerId = :followerId")
+  List<Long> findFolloweeIdsByFollowerId(@Param("followerId") Long followerId);
+}

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowPersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FollowPersistenceAdapter.java
@@ -1,0 +1,36 @@
+package com.conduit.article.adapter.out.persistence;
+
+import com.conduit.article.domain.port.out.FollowRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FollowPersistenceAdapter implements FollowRepository {
+
+  private final FollowJpaRepository followJpaRepository;
+
+  public FollowPersistenceAdapter(FollowJpaRepository followJpaRepository) {
+    this.followJpaRepository = followJpaRepository;
+  }
+
+  @Override
+  public boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId) {
+    return followJpaRepository.existsByFollowerIdAndFolloweeId(followerId, followeeId);
+  }
+
+  @Override
+  public Set<Long> findFollowedUserIds(Long followerId, List<Long> userIds) {
+    if (userIds == null || userIds.isEmpty()) {
+      return Set.of();
+    }
+    return new HashSet<>(
+        followJpaRepository.findFolloweeIdsByFollowerIdAndFolloweeIdIn(followerId, userIds));
+  }
+
+  @Override
+  public List<Long> findFolloweeIds(Long followerId) {
+    return followJpaRepository.findFolloweeIdsByFollowerId(followerId);
+  }
+}

--- a/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
+++ b/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
@@ -3,9 +3,12 @@ package com.conduit.article.application.service;
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.in.CreateArticleUseCase;
 import com.conduit.article.domain.port.in.DeleteArticleUseCase;
+import com.conduit.article.domain.port.in.FeedArticlesUseCase;
 import com.conduit.article.domain.port.in.GetArticleUseCase;
+import com.conduit.article.domain.port.in.ListArticlesUseCase;
 import com.conduit.article.domain.port.in.UpdateArticleUseCase;
 import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -14,12 +17,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class ArticleService
-    implements CreateArticleUseCase, GetArticleUseCase, UpdateArticleUseCase, DeleteArticleUseCase {
+    implements CreateArticleUseCase,
+        GetArticleUseCase,
+        UpdateArticleUseCase,
+        DeleteArticleUseCase,
+        ListArticlesUseCase,
+        FeedArticlesUseCase {
 
   private final ArticleRepository articleRepository;
+  private final FollowRepository followRepository;
 
-  public ArticleService(ArticleRepository articleRepository) {
+  public ArticleService(ArticleRepository articleRepository, FollowRepository followRepository) {
     this.articleRepository = articleRepository;
+    this.followRepository = followRepository;
   }
 
   @Override
@@ -86,5 +96,38 @@ public class ArticleService
     }
 
     articleRepository.delete(article);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Article> listArticles(
+      String tag, String author, String favorited, int limit, int offset) {
+    return articleRepository.findAll(tag, author, favorited, limit, offset);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public long countArticles(String tag, String author, String favorited) {
+    return articleRepository.countAll(tag, author, favorited);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Article> feedArticles(Long userId, int limit, int offset) {
+    List<Long> followeeIds = followRepository.findFolloweeIds(userId);
+    if (followeeIds.isEmpty()) {
+      return List.of();
+    }
+    return articleRepository.findByAuthorIds(followeeIds, limit, offset);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public long countFeedArticles(Long userId) {
+    List<Long> followeeIds = followRepository.findFolloweeIds(userId);
+    if (followeeIds.isEmpty()) {
+      return 0;
+    }
+    return articleRepository.countByAuthorIds(followeeIds);
   }
 }

--- a/backend/src/main/java/com/conduit/article/domain/model/ArticleWithMeta.java
+++ b/backend/src/main/java/com/conduit/article/domain/model/ArticleWithMeta.java
@@ -1,0 +1,3 @@
+package com.conduit.article.domain.model;
+
+public record ArticleWithMeta(Article article, boolean favorited, boolean following) {}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/FeedArticlesUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/FeedArticlesUseCase.java
@@ -1,0 +1,11 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+import java.util.List;
+
+public interface FeedArticlesUseCase {
+
+  List<Article> feedArticles(Long userId, int limit, int offset);
+
+  long countFeedArticles(Long userId);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/ListArticlesUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/ListArticlesUseCase.java
@@ -1,0 +1,11 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+import java.util.List;
+
+public interface ListArticlesUseCase {
+
+  List<Article> listArticles(String tag, String author, String favorited, int limit, int offset);
+
+  long countArticles(String tag, String author, String favorited);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/out/ArticleRepository.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/out/ArticleRepository.java
@@ -1,6 +1,7 @@
 package com.conduit.article.domain.port.out;
 
 import com.conduit.article.domain.model.Article;
+import java.util.List;
 import java.util.Optional;
 
 public interface ArticleRepository {
@@ -12,4 +13,13 @@ public interface ArticleRepository {
   void delete(Article article);
 
   boolean existsBySlug(String slug);
+
+  List<Article> findAll(
+      String tag, String authorUsername, String favoritedByUsername, int limit, int offset);
+
+  long countAll(String tag, String authorUsername, String favoritedByUsername);
+
+  List<Article> findByAuthorIds(List<Long> authorIds, int limit, int offset);
+
+  long countByAuthorIds(List<Long> authorIds);
 }

--- a/backend/src/main/java/com/conduit/article/domain/port/out/FavoriteRepository.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/out/FavoriteRepository.java
@@ -1,0 +1,11 @@
+package com.conduit.article.domain.port.out;
+
+import java.util.List;
+import java.util.Set;
+
+public interface FavoriteRepository {
+
+  boolean existsByUserIdAndArticleId(Long userId, Long articleId);
+
+  Set<Long> findFavoritedArticleIds(Long userId, List<Long> articleIds);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/out/FollowRepository.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/out/FollowRepository.java
@@ -1,0 +1,13 @@
+package com.conduit.article.domain.port.out;
+
+import java.util.List;
+import java.util.Set;
+
+public interface FollowRepository {
+
+  boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+
+  Set<Long> findFollowedUserIds(Long followerId, List<Long> userIds);
+
+  List<Long> findFolloweeIds(Long followerId);
+}

--- a/backend/src/main/java/com/conduit/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/com/conduit/shared/security/SecurityConfig.java
@@ -39,8 +39,10 @@ public class SecurityConfig {
                     // Public endpoints
                     .requestMatchers(HttpMethod.POST, "/api/users", "/api/users/login")
                     .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/articles", "/api/articles/feed")
+                    .requestMatchers(HttpMethod.GET, "/api/articles")
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/articles/feed")
+                    .authenticated()
                     .requestMatchers(HttpMethod.GET, "/api/articles/{slug}")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/articles/{slug}/comments")

--- a/backend/src/test/java/com/conduit/article/adapter/in/web/ArticleListFeedIntegrationTest.java
+++ b/backend/src/test/java/com/conduit/article/adapter/in/web/ArticleListFeedIntegrationTest.java
@@ -1,0 +1,407 @@
+package com.conduit.article.adapter.in.web;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.conduit.article.adapter.out.persistence.ArticleJpaRepository;
+import com.conduit.article.adapter.out.persistence.FavoriteJpaEntity;
+import com.conduit.article.adapter.out.persistence.FavoriteJpaRepository;
+import com.conduit.article.adapter.out.persistence.FollowJpaEntity;
+import com.conduit.article.adapter.out.persistence.FollowJpaRepository;
+import com.conduit.shared.security.JwtTokenProvider;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Article List & Feed Integration Tests")
+class ArticleListFeedIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private JwtTokenProvider jwtTokenProvider;
+  @Autowired private FollowJpaRepository followJpaRepository;
+  @Autowired private FavoriteJpaRepository favoriteJpaRepository;
+  @Autowired private ArticleJpaRepository articleJpaRepository;
+
+  // === Helper types and methods ===
+
+  private record UserInfo(String token, Long userId) {}
+
+  private UserInfo registerUser(String username, String email, String password) throws Exception {
+    String body =
+        """
+        {"user":{"username":"%s","email":"%s","password":"%s"}}
+        """
+            .formatted(username, email, password);
+
+    MvcResult result =
+        mockMvc
+            .perform(post("/api/users").contentType(MediaType.APPLICATION_JSON).content(body))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String token = JsonPath.read(result.getResponse().getContentAsString(), "$.user.token");
+    Long userId = jwtTokenProvider.extractUserId(token);
+    return new UserInfo(token, userId);
+  }
+
+  private String createArticle(
+      String token, String title, String description, String articleBody, String tagsJson)
+      throws Exception {
+    String requestBody =
+        """
+        {"article":{"title":"%s","description":"%s","body":"%s","tagList":[%s]}}
+        """
+            .formatted(title, description, articleBody, tagsJson);
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                post("/api/articles")
+                    .header("Authorization", "Token " + token)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    return JsonPath.read(result.getResponse().getContentAsString(), "$.article.slug");
+  }
+
+  private Long findArticleIdBySlug(String slug) {
+    return articleJpaRepository
+        .findBySlug(slug)
+        .orElseThrow(() -> new IllegalStateException("Article not found: " + slug))
+        .getId();
+  }
+
+  // === GET /api/articles (List Articles) ===
+
+  @Nested
+  @DisplayName("GET /api/articles")
+  class ListArticles {
+
+    @Test
+    @DisplayName("should return empty list when no articles exist")
+    void emptyList() throws Exception {
+      mockMvc
+          .perform(get("/api/articles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles").isArray())
+          .andExpect(jsonPath("$.articles", hasSize(0)))
+          .andExpect(jsonPath("$.articlesCount").value(0));
+    }
+
+    @Test
+    @DisplayName("should return articles list with count")
+    void returnsList() throws Exception {
+      UserInfo user = registerUser("jacob", "jake@jake.com", "jakejake1");
+      createArticle(user.token(), "First Article", "Desc 1", "Body 1", "");
+      createArticle(user.token(), "Second Article", "Desc 2", "Body 2", "");
+
+      mockMvc
+          .perform(get("/api/articles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(2)))
+          .andExpect(jsonPath("$.articlesCount").value(2));
+    }
+
+    @Test
+    @DisplayName("should order articles by most recent first")
+    void mostRecentFirst() throws Exception {
+      UserInfo user = registerUser("jacob", "jake@jake.com", "jakejake1");
+      createArticle(user.token(), "First Article", "Desc 1", "Body 1", "");
+      createArticle(user.token(), "Second Article", "Desc 2", "Body 2", "");
+
+      mockMvc
+          .perform(get("/api/articles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].title").value("Second Article"))
+          .andExpect(jsonPath("$.articles[1].title").value("First Article"));
+    }
+
+    @Test
+    @DisplayName("should filter articles by tag")
+    void filterByTag() throws Exception {
+      UserInfo user = registerUser("jacob", "jake@jake.com", "jakejake1");
+      createArticle(user.token(), "Tagged Article", "Desc", "Body", "\"dragons\"");
+      createArticle(user.token(), "No Tag Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(get("/api/articles").param("tag", "dragons"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(1)))
+          .andExpect(jsonPath("$.articlesCount").value(1))
+          .andExpect(jsonPath("$.articles[0].title").value("Tagged Article"));
+    }
+
+    @Test
+    @DisplayName("should filter articles by author username")
+    void filterByAuthor() throws Exception {
+      UserInfo user1 = registerUser("author1", "author1@test.com", "password123");
+      UserInfo user2 = registerUser("author2", "author2@test.com", "password123");
+      createArticle(user1.token(), "Author1 Article", "Desc", "Body", "");
+      createArticle(user2.token(), "Author2 Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(get("/api/articles").param("author", "author1"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(1)))
+          .andExpect(jsonPath("$.articlesCount").value(1))
+          .andExpect(jsonPath("$.articles[0].author.username").value("author1"));
+    }
+
+    @Test
+    @DisplayName("should filter articles favorited by username")
+    void filterByFavorited() throws Exception {
+      UserInfo author = registerUser("theauthor", "author@test.com", "password123");
+      UserInfo favUser = registerUser("favuser", "fav@test.com", "password123");
+
+      String favSlug =
+          createArticle(author.token(), "Favorited Article", "Desc", "Body", "");
+      createArticle(author.token(), "Normal Article", "Desc", "Body", "");
+
+      Long favArticleId = findArticleIdBySlug(favSlug);
+      favoriteJpaRepository.saveAndFlush(new FavoriteJpaEntity(favUser.userId(), favArticleId));
+
+      mockMvc
+          .perform(get("/api/articles").param("favorited", "favuser"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(1)))
+          .andExpect(jsonPath("$.articlesCount").value(1))
+          .andExpect(jsonPath("$.articles[0].title").value("Favorited Article"));
+    }
+
+    @Test
+    @DisplayName("should support pagination with limit and offset")
+    void pagination() throws Exception {
+      UserInfo user = registerUser("jacob", "jake@jake.com", "jakejake1");
+      createArticle(user.token(), "Article 1", "Desc", "Body", "");
+      createArticle(user.token(), "Article 2", "Desc", "Body", "");
+      createArticle(user.token(), "Article 3", "Desc", "Body", "");
+
+      mockMvc
+          .perform(get("/api/articles").param("limit", "2").param("offset", "0"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(2)))
+          .andExpect(jsonPath("$.articlesCount").value(3))
+          .andExpect(jsonPath("$.articles[0].title").value("Article 3"))
+          .andExpect(jsonPath("$.articles[1].title").value("Article 2"));
+
+      mockMvc
+          .perform(get("/api/articles").param("limit", "2").param("offset", "2"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(1)))
+          .andExpect(jsonPath("$.articlesCount").value(3))
+          .andExpect(jsonPath("$.articles[0].title").value("Article 1"));
+    }
+
+    @Test
+    @DisplayName("should include all expected fields in response format")
+    void responseFormat() throws Exception {
+      UserInfo user = registerUser("jacob", "jake@jake.com", "jakejake1");
+      createArticle(user.token(), "Test Article", "Desc", "Body", "\"tag1\"");
+
+      mockMvc
+          .perform(get("/api/articles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].slug").isNotEmpty())
+          .andExpect(jsonPath("$.articles[0].title").value("Test Article"))
+          .andExpect(jsonPath("$.articles[0].description").value("Desc"))
+          .andExpect(jsonPath("$.articles[0].tagList[0]").value("tag1"))
+          .andExpect(jsonPath("$.articles[0].createdAt").isNotEmpty())
+          .andExpect(jsonPath("$.articles[0].updatedAt").isNotEmpty())
+          .andExpect(jsonPath("$.articles[0].favorited").value(false))
+          .andExpect(jsonPath("$.articles[0].favoritesCount").value(0))
+          .andExpect(jsonPath("$.articles[0].author.username").value("jacob"))
+          .andExpect(jsonPath("$.articles[0].author.following").value(false));
+    }
+
+    @Test
+    @DisplayName("should show favorited=true when authenticated user has favorited the article")
+    void favoritedWhenAuthenticated() throws Exception {
+      UserInfo author = registerUser("author", "author@test.com", "password123");
+      UserInfo reader = registerUser("reader", "reader@test.com", "password123");
+      String slug = createArticle(author.token(), "Great Article", "Desc", "Body", "");
+
+      Long articleId = findArticleIdBySlug(slug);
+      favoriteJpaRepository.saveAndFlush(new FavoriteJpaEntity(reader.userId(), articleId));
+
+      mockMvc
+          .perform(get("/api/articles").header("Authorization", "Token " + reader.token()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].favorited").value(true));
+    }
+
+    @Test
+    @DisplayName("should show following=true when authenticated user follows the author")
+    void followingWhenAuthenticated() throws Exception {
+      UserInfo author = registerUser("author", "author@test.com", "password123");
+      UserInfo reader = registerUser("reader", "reader@test.com", "password123");
+      createArticle(author.token(), "Great Article", "Desc", "Body", "");
+
+      followJpaRepository.saveAndFlush(
+          new FollowJpaEntity(reader.userId(), author.userId()));
+
+      mockMvc
+          .perform(get("/api/articles").header("Authorization", "Token " + reader.token()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].author.following").value(true));
+    }
+
+    @Test
+    @DisplayName("should show favorited=false and following=false without authentication")
+    void noAuthDefaults() throws Exception {
+      UserInfo author = registerUser("author", "author@test.com", "password123");
+      UserInfo reader = registerUser("reader", "reader@test.com", "password123");
+      String slug = createArticle(author.token(), "Great Article", "Desc", "Body", "");
+
+      Long articleId = findArticleIdBySlug(slug);
+      followJpaRepository.saveAndFlush(
+          new FollowJpaEntity(reader.userId(), author.userId()));
+      favoriteJpaRepository.saveAndFlush(new FavoriteJpaEntity(reader.userId(), articleId));
+
+      mockMvc
+          .perform(get("/api/articles"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].favorited").value(false))
+          .andExpect(jsonPath("$.articles[0].author.following").value(false));
+    }
+  }
+
+  // === GET /api/articles/feed ===
+
+  @Nested
+  @DisplayName("GET /api/articles/feed")
+  class FeedArticles {
+
+    @Test
+    @DisplayName("should return 401 without authentication")
+    void unauthorized() throws Exception {
+      mockMvc.perform(get("/api/articles/feed")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should return empty feed when user follows nobody")
+    void emptyFeed() throws Exception {
+      UserInfo user = registerUser("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc
+          .perform(
+              get("/api/articles/feed").header("Authorization", "Token " + user.token()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(0)))
+          .andExpect(jsonPath("$.articlesCount").value(0));
+    }
+
+    @Test
+    @DisplayName("should return articles from followed users only")
+    void followedUserArticles() throws Exception {
+      UserInfo follower = registerUser("follower", "follower@test.com", "password123");
+      UserInfo followed = registerUser("followed", "followed@test.com", "password123");
+      UserInfo stranger = registerUser("stranger", "stranger@test.com", "password123");
+
+      createArticle(followed.token(), "Followed Article", "Desc", "Body", "");
+      createArticle(stranger.token(), "Stranger Article", "Desc", "Body", "");
+
+      followJpaRepository.saveAndFlush(
+          new FollowJpaEntity(follower.userId(), followed.userId()));
+
+      mockMvc
+          .perform(
+              get("/api/articles/feed")
+                  .header("Authorization", "Token " + follower.token()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(1)))
+          .andExpect(jsonPath("$.articlesCount").value(1))
+          .andExpect(jsonPath("$.articles[0].title").value("Followed Article"))
+          .andExpect(jsonPath("$.articles[0].author.username").value("followed"));
+    }
+
+    @Test
+    @DisplayName("should support pagination for feed")
+    void feedPagination() throws Exception {
+      UserInfo follower = registerUser("follower", "follower@test.com", "password123");
+      UserInfo followed = registerUser("followed", "followed@test.com", "password123");
+
+      createArticle(followed.token(), "Article 1", "Desc", "Body", "");
+      createArticle(followed.token(), "Article 2", "Desc", "Body", "");
+      createArticle(followed.token(), "Article 3", "Desc", "Body", "");
+
+      followJpaRepository.saveAndFlush(
+          new FollowJpaEntity(follower.userId(), followed.userId()));
+
+      mockMvc
+          .perform(
+              get("/api/articles/feed")
+                  .header("Authorization", "Token " + follower.token())
+                  .param("limit", "2")
+                  .param("offset", "0"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles", hasSize(2)))
+          .andExpect(jsonPath("$.articlesCount").value(3));
+    }
+
+    @Test
+    @DisplayName("should include proper response fields in feed")
+    void feedResponseFormat() throws Exception {
+      UserInfo follower = registerUser("follower", "follower@test.com", "password123");
+      UserInfo followed = registerUser("followed", "followed@test.com", "password123");
+
+      createArticle(followed.token(), "Feed Article", "Desc", "Body", "\"tech\"");
+
+      followJpaRepository.saveAndFlush(
+          new FollowJpaEntity(follower.userId(), followed.userId()));
+
+      mockMvc
+          .perform(
+              get("/api/articles/feed")
+                  .header("Authorization", "Token " + follower.token()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].slug").isNotEmpty())
+          .andExpect(jsonPath("$.articles[0].title").value("Feed Article"))
+          .andExpect(jsonPath("$.articles[0].tagList[0]").value("tech"))
+          .andExpect(jsonPath("$.articles[0].favorited").value(false))
+          .andExpect(jsonPath("$.articles[0].favoritesCount").value(0))
+          .andExpect(jsonPath("$.articles[0].author.username").value("followed"))
+          .andExpect(jsonPath("$.articles[0].author.following").value(true));
+    }
+
+    @Test
+    @DisplayName("should show favorited=true in feed when user has favorited the article")
+    void feedFavoritedArticle() throws Exception {
+      UserInfo follower = registerUser("follower", "follower@test.com", "password123");
+      UserInfo followed = registerUser("followed", "followed@test.com", "password123");
+
+      String slug = createArticle(followed.token(), "Feed Article", "Desc", "Body", "");
+
+      followJpaRepository.saveAndFlush(
+          new FollowJpaEntity(follower.userId(), followed.userId()));
+
+      Long articleId = findArticleIdBySlug(slug);
+      favoriteJpaRepository.saveAndFlush(new FavoriteJpaEntity(follower.userId(), articleId));
+
+      mockMvc
+          .perform(
+              get("/api/articles/feed")
+                  .header("Authorization", "Token " + follower.token()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.articles[0].favorited").value(true))
+          .andExpect(jsonPath("$.articles[0].author.following").value(true));
+    }
+  }
+}

--- a/backend/src/test/java/com/conduit/article/application/service/ArticleServiceTest.java
+++ b/backend/src/test/java/com/conduit/article/application/service/ArticleServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import java.time.Instant;
 import java.util.List;
@@ -26,11 +27,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ArticleServiceTest {
 
   @Mock private ArticleRepository articleRepository;
+  @Mock private FollowRepository followRepository;
   private ArticleService articleService;
 
   @BeforeEach
   void setUp() {
-    articleService = new ArticleService(articleRepository);
+    articleService = new ArticleService(articleRepository, followRepository);
   }
 
   @Nested


### PR DESCRIPTION
## Summary
- `GET /api/articles` — tag/author/favorited 필터 + limit/offset 페이지네이션 (공개, 선택적 인증)
- `GET /api/articles/feed` — 팔로잉 사용자 아티클 조회 (JWT 필수)
- 응답에 `favorited`, `favoritesCount`, `author.following` 포함 — 비인증 시 false 기본값
- Favorite/Follow JPA 엔티티 + `@IdClass` 복합키 + 영속 어댑터
- `ArticlePersistenceAdapter`에 `EntityManager` 기반 동적 JPQL 쿼리
- SecurityConfig: `/api/articles/feed` 인증 필수로 분리

## Test Plan

### 1. 통합 테스트 (18 cases)
- [x] 빈 목록, 카운트 포함, 최신순 정렬
- [x] tag/author/favorited 필터
- [x] limit/offset 페이지네이션 + 총 개수
- [x] 인증 시 favorited=true, following=true
- [x] 비인증 시 favorited=false, following=false
- [x] Feed 401 without auth
- [x] Feed 팔로잉 사용자 아티클만 반환
- [x] Feed 페이지네이션

### 2. 단위 테스트
- [x] `ArticleServiceTest` — FollowRepository 의존성 추가 후 기존 11 cases 유지

### 3. 부팅 검증
- [x] `./gradlew test` BUILD SUCCESSFUL (전체 106 tests)

Closes #13

**Touched Areas**: `article/` (확장), `shared/security/` (SecurityConfig)

**Flow Mode**: add | Issue #13 auto-detected as `type:feature` → mode=add