### PR TITLE
feat(backend): Profile 조회 + Follow/Unfollow 엔드포인트

### DIFF
--- a/backend/src/main/java/com/conduit/profile/adapter/in/web/ProfileController.java
+++ b/backend/src/main/java/com/conduit/profile/adapter/in/web/ProfileController.java
@@ -1,0 +1,77 @@
+package com.conduit.profile.adapter.in.web;
+
+import com.conduit.profile.domain.model.Profile;
+import com.conduit.profile.domain.port.in.FollowUserUseCase;
+import com.conduit.profile.domain.port.in.GetProfileUseCase;
+import com.conduit.profile.domain.port.in.UnfollowUserUseCase;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/profiles")
+public class ProfileController {
+
+    private final GetProfileUseCase getProfileUseCase;
+    private final FollowUserUseCase followUserUseCase;
+    private final UnfollowUserUseCase unfollowUserUseCase;
+
+    public ProfileController(GetProfileUseCase getProfileUseCase,
+                              FollowUserUseCase followUserUseCase,
+                              UnfollowUserUseCase unfollowUserUseCase) {
+        this.getProfileUseCase = getProfileUseCase;
+        this.followUserUseCase = followUserUseCase;
+        this.unfollowUserUseCase = unfollowUserUseCase;
+    }
+
+    @GetMapping("/{username}")
+    public ResponseEntity<Map<String, Object>> getProfile(
+            @PathVariable String username,
+            Authentication authentication) {
+        Long currentUserId = getCurrentUserId(authentication);
+        Profile profile = getProfileUseCase.getProfile(username, currentUserId);
+        return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
+    }
+
+    @PostMapping("/{username}/follow")
+    public ResponseEntity<Map<String, Object>> follow(
+            @PathVariable String username,
+            Authentication authentication) {
+        Long currentUserId = getCurrentUserId(authentication);
+        Profile profile = followUserUseCase.follow(username, currentUserId);
+        return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
+    }
+
+    @DeleteMapping("/{username}/follow")
+    public ResponseEntity<Map<String, Object>> unfollow(
+            @PathVariable String username,
+            Authentication authentication) {
+        Long currentUserId = getCurrentUserId(authentication);
+        Profile profile = unfollowUserUseCase.unfollow(username, currentUserId);
+        return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
+    }
+
+    private Long getCurrentUserId(Authentication authentication) {
+        if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
+            return userId;
+        }
+        return null;
+    }
+
+    private Map<String, Object> toResponse(Profile profile) {
+        return Map.of(
+                "username", profile.username(),
+                "bio", profile.bio() != null ? profile.bio() : "",
+                "image", profile.image() != null ? profile.image() : "",
+                "following", profile.following()
+        );
+    }
+}

--- a/backend/src/main/java/com/conduit/profile/adapter/out/persistence/ProfileFollowPersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/profile/adapter/out/persistence/ProfileFollowPersistenceAdapter.java
@@ -1,0 +1,33 @@
+package com.conduit.profile.adapter.out.persistence;
+
+import com.conduit.article.adapter.out.persistence.FollowId;
+import com.conduit.article.adapter.out.persistence.FollowJpaEntity;
+import com.conduit.article.adapter.out.persistence.FollowJpaRepository;
+import com.conduit.profile.domain.port.out.ProfileFollowRepository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProfileFollowPersistenceAdapter implements ProfileFollowRepository {
+
+    private final FollowJpaRepository followJpaRepository;
+
+    public ProfileFollowPersistenceAdapter(FollowJpaRepository followJpaRepository) {
+        this.followJpaRepository = followJpaRepository;
+    }
+
+    @Override
+    public boolean isFollowing(Long followerId, Long followeeId) {
+        return followJpaRepository.existsByFollowerIdAndFolloweeId(followerId, followeeId);
+    }
+
+    @Override
+    public void follow(Long followerId, Long followeeId) {
+        followJpaRepository.save(new FollowJpaEntity(followerId, followeeId));
+    }
+
+    @Override
+    public void unfollow(Long followerId, Long followeeId) {
+        followJpaRepository.deleteById(new FollowId(followerId, followeeId));
+    }
+}

--- a/backend/src/main/java/com/conduit/profile/adapter/out/persistence/ProfileUserPersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/profile/adapter/out/persistence/ProfileUserPersistenceAdapter.java
@@ -1,0 +1,55 @@
+package com.conduit.profile.adapter.out.persistence;
+
+import com.conduit.article.adapter.out.persistence.FollowJpaRepository;
+import com.conduit.profile.domain.model.Profile;
+import com.conduit.profile.domain.port.out.ProfileUserRepository;
+import com.conduit.user.adapter.out.persistence.UserJpaEntity;
+import com.conduit.user.adapter.out.persistence.UserJpaRepository;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class ProfileUserPersistenceAdapter implements ProfileUserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+    private final FollowJpaRepository followJpaRepository;
+
+    public ProfileUserPersistenceAdapter(UserJpaRepository userJpaRepository,
+                                          FollowJpaRepository followJpaRepository) {
+        this.userJpaRepository = userJpaRepository;
+        this.followJpaRepository = followJpaRepository;
+    }
+
+    @Override
+    public Optional<Profile> findByUsername(String username, Long currentUserId) {
+        return userJpaRepository.findByUsername(username)
+                .map(entity -> toProfile(entity, currentUserId));
+    }
+
+    @Override
+    public boolean existsByUsername(String username) {
+        return userJpaRepository.existsByUsername(username);
+    }
+
+    @Override
+    public Long findUserIdByUsername(String username) {
+        return userJpaRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + username))
+                .getId();
+    }
+
+    private Profile toProfile(UserJpaEntity entity, Long currentUserId) {
+        boolean following = false;
+        if (currentUserId != null) {
+            following = followJpaRepository.existsByFollowerIdAndFolloweeId(currentUserId, entity.getId());
+        }
+        return new Profile(
+                entity.getUsername(),
+                entity.getBio(),
+                entity.getImage(),
+                following
+        );
+    }
+}

--- a/backend/src/main/java/com/conduit/profile/application/service/ProfileService.java
+++ b/backend/src/main/java/com/conduit/profile/application/service/ProfileService.java
@@ -1,0 +1,71 @@
+package com.conduit.profile.application.service;
+
+import com.conduit.profile.domain.model.Profile;
+import com.conduit.profile.domain.port.in.FollowUserUseCase;
+import com.conduit.profile.domain.port.in.GetProfileUseCase;
+import com.conduit.profile.domain.port.in.UnfollowUserUseCase;
+import com.conduit.profile.domain.port.out.ProfileFollowRepository;
+import com.conduit.profile.domain.port.out.ProfileUserRepository;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ProfileService implements GetProfileUseCase, FollowUserUseCase, UnfollowUserUseCase {
+
+    private final ProfileUserRepository userRepository;
+    private final ProfileFollowRepository followRepository;
+
+    public ProfileService(ProfileUserRepository userRepository,
+                          ProfileFollowRepository followRepository) {
+        this.userRepository = userRepository;
+        this.followRepository = followRepository;
+    }
+
+    @Override
+    public Profile getProfile(String username, Long currentUserId) {
+        return userRepository.findByUsername(username, currentUserId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + username));
+    }
+
+    @Override
+    @Transactional
+    public Profile follow(String username, Long currentUserId) {
+        if (!userRepository.existsByUsername(username)) {
+            throw new IllegalArgumentException("User not found: " + username);
+        }
+
+        Long targetUserId = userRepository.findUserIdByUsername(username);
+
+        if (targetUserId.equals(currentUserId)) {
+            throw new IllegalArgumentException("Cannot follow yourself");
+        }
+
+        if (!followRepository.isFollowing(currentUserId, targetUserId)) {
+            followRepository.follow(currentUserId, targetUserId);
+        }
+
+        return new Profile(username,
+                userRepository.findByUsername(username, currentUserId).orElseThrow().bio(),
+                userRepository.findByUsername(username, currentUserId).orElseThrow().image(),
+                true);
+    }
+
+    @Override
+    @Transactional
+    public Profile unfollow(String username, Long currentUserId) {
+        if (!userRepository.existsByUsername(username)) {
+            throw new IllegalArgumentException("User not found: " + username);
+        }
+
+        Long targetUserId = userRepository.findUserIdByUsername(username);
+
+        followRepository.unfollow(currentUserId, targetUserId);
+
+        return new Profile(username,
+                userRepository.findByUsername(username, currentUserId).orElseThrow().bio(),
+                userRepository.findByUsername(username, currentUserId).orElseThrow().image(),
+                false);
+    }
+}

--- a/backend/src/main/java/com/conduit/profile/domain/model/Profile.java
+++ b/backend/src/main/java/com/conduit/profile/domain/model/Profile.java
@@ -1,0 +1,8 @@
+package com.conduit.profile.domain.model;
+
+public record Profile(
+        String username,
+        String bio,
+        String image,
+        boolean following
+) {}

--- a/backend/src/main/java/com/conduit/profile/domain/port/in/FollowUserUseCase.java
+++ b/backend/src/main/java/com/conduit/profile/domain/port/in/FollowUserUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.profile.domain.port.in;
+
+import com.conduit.profile.domain.model.Profile;
+
+public interface FollowUserUseCase {
+
+    Profile follow(String username, Long currentUserId);
+}

--- a/backend/src/main/java/com/conduit/profile/domain/port/in/GetProfileUseCase.java
+++ b/backend/src/main/java/com/conduit/profile/domain/port/in/GetProfileUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.profile.domain.port.in;
+
+import com.conduit.profile.domain.model.Profile;
+
+public interface GetProfileUseCase {
+
+    Profile getProfile(String username, Long currentUserId);
+}

--- a/backend/src/main/java/com/conduit/profile/domain/port/in/UnfollowUserUseCase.java
+++ b/backend/src/main/java/com/conduit/profile/domain/port/in/UnfollowUserUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.profile.domain.port.in;
+
+import com.conduit.profile.domain.model.Profile;
+
+public interface UnfollowUserUseCase {
+
+    Profile unfollow(String username, Long currentUserId);
+}

--- a/backend/src/main/java/com/conduit/profile/domain/port/out/ProfileFollowRepository.java
+++ b/backend/src/main/java/com/conduit/profile/domain/port/out/ProfileFollowRepository.java
@@ -1,0 +1,10 @@
+package com.conduit.profile.domain.port.out;
+
+public interface ProfileFollowRepository {
+
+    boolean isFollowing(Long followerId, Long followeeId);
+
+    void follow(Long followerId, Long followeeId);
+
+    void unfollow(Long followerId, Long followeeId);
+}

--- a/backend/src/main/java/com/conduit/profile/domain/port/out/ProfileUserRepository.java
+++ b/backend/src/main/java/com/conduit/profile/domain/port/out/ProfileUserRepository.java
@@ -1,0 +1,14 @@
+package com.conduit.profile.domain.port.out;
+
+import com.conduit.profile.domain.model.Profile;
+
+import java.util.Optional;
+
+public interface ProfileUserRepository {
+
+    Optional<Profile> findByUsername(String username, Long currentUserId);
+
+    boolean existsByUsername(String username);
+
+    Long findUserIdByUsername(String username);
+}

--- a/backend/src/test/java/com/conduit/profile/ProfileIntegrationTest.java
+++ b/backend/src/test/java/com/conduit/profile/ProfileIntegrationTest.java
@@ -1,0 +1,129 @@
+package com.conduit.profile;
+
+import com.conduit.user.adapter.out.persistence.UserJpaEntity;
+import com.conduit.user.adapter.out.persistence.UserJpaRepository;
+import com.conduit.shared.security.JwtTokenProvider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ProfileIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserJpaRepository userRepository;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    private UserJpaEntity user1;
+    private UserJpaEntity user2;
+    private String token1;
+
+    @BeforeEach
+    void setUp() {
+        user1 = userRepository.save(
+                new UserJpaEntity("user1@test.com", "user1", passwordEncoder.encode("pass"), null, null));
+        token1 = jwtTokenProvider.generateToken(user1.getId());
+
+        user2 = userRepository.save(
+                new UserJpaEntity("user2@test.com", "user2", passwordEncoder.encode("pass"), null, null));
+    }
+
+    @Test
+    void getProfile_unauthenticated_returnsFollowingFalse() throws Exception {
+        mockMvc.perform(get("/api/profiles/user2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.username").value("user2"))
+                .andExpect(jsonPath("$.profile.following").value(false));
+    }
+
+    @Test
+    void getProfile_authenticated_returnsFollowingFalse() throws Exception {
+        mockMvc.perform(get("/api/profiles/user2")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.username").value("user2"))
+                .andExpect(jsonPath("$.profile.following").value(false));
+    }
+
+    @Test
+    void getProfile_notFound_returns500() throws Exception {
+        mockMvc.perform(get("/api/profiles/nonexistent"))
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    void follow_thenGetProfile_returnsFollowingTrue() throws Exception {
+        mockMvc.perform(post("/api/profiles/user2/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.username").value("user2"))
+                .andExpect(jsonPath("$.profile.following").value(true));
+
+        // Verify via GET
+        mockMvc.perform(get("/api/profiles/user2")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(jsonPath("$.profile.following").value(true));
+    }
+
+    @Test
+    void follow_idempotent() throws Exception {
+        mockMvc.perform(post("/api/profiles/user2/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk());
+
+        // Follow again — should still succeed
+        mockMvc.perform(post("/api/profiles/user2/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.following").value(true));
+    }
+
+    @Test
+    void unfollow_afterFollow_returnsFollowingFalse() throws Exception {
+        // Follow first
+        mockMvc.perform(post("/api/profiles/user2/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk());
+
+        // Unfollow
+        mockMvc.perform(delete("/api/profiles/user2/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.username").value("user2"))
+                .andExpect(jsonPath("$.profile.following").value(false));
+    }
+
+    @Test
+    void follow_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/profiles/user2/follow"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void follow_nonexistentUser_returns500() throws Exception {
+        mockMvc.perform(post("/api/profiles/ghost/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    void follow_self_returns500() throws Exception {
+        mockMvc.perform(post("/api/profiles/user1/follow")
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().is5xxServerError());
+    }
+}

--- a/backend/src/test/java/com/conduit/profile/application/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/conduit/profile/application/service/ProfileServiceTest.java
@@ -1,0 +1,108 @@
+package com.conduit.profile.application.service;
+
+import com.conduit.profile.domain.model.Profile;
+import com.conduit.profile.domain.port.out.ProfileFollowRepository;
+import com.conduit.profile.domain.port.out.ProfileUserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class ProfileServiceTest {
+
+    private ProfileUserRepository userRepository;
+    private ProfileFollowRepository followRepository;
+    private ProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(ProfileUserRepository.class);
+        followRepository = mock(ProfileFollowRepository.class);
+        service = new ProfileService(userRepository, followRepository);
+    }
+
+    @Test
+    void getProfile_returnsProfile() {
+        Profile expected = new Profile("jake", "bio", "img.png", false);
+        when(userRepository.findByUsername("jake", 1L)).thenReturn(Optional.of(expected));
+
+        Profile result = service.getProfile("jake", 1L);
+
+        assertThat(result.username()).isEqualTo("jake");
+        assertThat(result.following()).isFalse();
+    }
+
+    @Test
+    void getProfile_userNotFound_throws() {
+        when(userRepository.findByUsername("ghost", null)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getProfile("ghost", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void follow_createsFollow_returnsFollowingTrue() {
+        when(userRepository.existsByUsername("jake")).thenReturn(true);
+        when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
+        when(followRepository.isFollowing(1L, 2L)).thenReturn(false);
+        when(userRepository.findByUsername("jake", 1L))
+                .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", true)));
+
+        Profile result = service.follow("jake", 1L);
+
+        assertThat(result.following()).isTrue();
+        verify(followRepository).follow(1L, 2L);
+    }
+
+    @Test
+    void follow_alreadyFollowing_idempotent() {
+        when(userRepository.existsByUsername("jake")).thenReturn(true);
+        when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
+        when(followRepository.isFollowing(1L, 2L)).thenReturn(true);
+        when(userRepository.findByUsername("jake", 1L))
+                .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", true)));
+
+        Profile result = service.follow("jake", 1L);
+
+        assertThat(result.following()).isTrue();
+        verify(followRepository, never()).follow(anyLong(), anyLong());
+    }
+
+    @Test
+    void follow_self_throws() {
+        when(userRepository.existsByUsername("me")).thenReturn(true);
+        when(userRepository.findUserIdByUsername("me")).thenReturn(1L);
+
+        assertThatThrownBy(() -> service.follow("me", 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot follow yourself");
+    }
+
+    @Test
+    void unfollow_removesFollow_returnsFollowingFalse() {
+        when(userRepository.existsByUsername("jake")).thenReturn(true);
+        when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
+        when(userRepository.findByUsername("jake", 1L))
+                .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", false)));
+
+        Profile result = service.unfollow("jake", 1L);
+
+        assertThat(result.following()).isFalse();
+        verify(followRepository).unfollow(1L, 2L);
+    }
+
+    @Test
+    void unfollow_userNotFound_throws() {
+        when(userRepository.existsByUsername("ghost")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.unfollow("ghost", 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("User not found");
+    }
+}


### PR DESCRIPTION
## Summary
- `profile` 모듈 전체 구현 (Hexagonal Architecture): domain model, 3 use case ports, service, persistence adapters, REST controller
- `GET /api/profiles/:username` — 비인증 시 following=false, 인증 시 실제 팔로우 상태 반영
- `POST /api/profiles/:username/follow` — 팔로우 (멱등, 자기 팔로우 방지)
- `DELETE /api/profiles/:username/follow` — 언팔로우
- 기존 article 모듈의 `FollowJpaRepository`/`FollowJpaEntity` 재사용 (cross-module 참조)

## Test Plan

### 1. Unit (7건)
- ProfileServiceTest: getProfile 성공/실패, follow 성공/멱등/자기팔로우, unfollow 성공/실패

### 2. Integration (9건)
- 비인증 프로필 조회 → following=false
- 인증 프로필 조회 → following=false
- 존재하지 않는 유저 → 500
- 팔로우 → following=true + GET 확인
- 중복 팔로우 멱등성
- 언팔로우 → following=false
- 비인증 팔로우 → 401
- 존재하지 않는 유저 팔로우 → 500
- 자기 팔로우 → 500

### 3. All Backend Tests
- BUILD SUCCESSFUL — 전체 테스트 통과

## Flow
- Mode: **add** (auto-detected)
- Issue: Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)