### PR TITLE
feat(backend): Comment CRUD — 추가/목록/삭제 + 권한 검증

### DIFF
--- a/backend/src/main/java/com/conduit/comment/adapter/in/web/CommentController.java
+++ b/backend/src/main/java/com/conduit/comment/adapter/in/web/CommentController.java
@@ -1,0 +1,109 @@
+package com.conduit.comment.adapter.in.web;
+
+import com.conduit.comment.domain.model.Comment;
+import com.conduit.comment.domain.port.in.AddCommentUseCase;
+import com.conduit.comment.domain.port.in.DeleteCommentUseCase;
+import com.conduit.comment.domain.port.in.ListCommentsUseCase;
+import com.conduit.user.domain.model.User;
+import com.conduit.user.domain.port.out.UserRepository;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/articles/{slug}/comments")
+public class CommentController {
+
+    private final AddCommentUseCase addCommentUseCase;
+    private final ListCommentsUseCase listCommentsUseCase;
+    private final DeleteCommentUseCase deleteCommentUseCase;
+    private final UserRepository userRepository;
+
+    public CommentController(AddCommentUseCase addCommentUseCase,
+                              ListCommentsUseCase listCommentsUseCase,
+                              DeleteCommentUseCase deleteCommentUseCase,
+                              UserRepository userRepository) {
+        this.addCommentUseCase = addCommentUseCase;
+        this.listCommentsUseCase = listCommentsUseCase;
+        this.deleteCommentUseCase = deleteCommentUseCase;
+        this.userRepository = userRepository;
+    }
+
+    public record AddCommentRequest(
+            @Valid CommentBody comment
+    ) {
+        public record CommentBody(
+                @NotBlank String body
+        ) {}
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> addComment(
+            @PathVariable String slug,
+            @RequestBody @Valid AddCommentRequest request,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        Comment comment = addCommentUseCase.addComment(slug, request.comment().body(), userId);
+        return ResponseEntity.ok(Map.of("comment", toResponse(comment)));
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> listComments(@PathVariable String slug) {
+        List<Comment> comments = listCommentsUseCase.listComments(slug);
+        List<Map<String, Object>> responses = comments.stream()
+                .map(this::toResponse)
+                .toList();
+        return ResponseEntity.ok(Map.of("comments", responses));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable String slug,
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        deleteCommentUseCase.deleteComment(slug, id, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    private Map<String, Object> toResponse(Comment comment) {
+        User author = userRepository.findById(comment.authorId()).orElse(null);
+
+        Map<String, Object> authorMap = new LinkedHashMap<>();
+        if (author != null) {
+            authorMap.put("username", author.getUsername());
+            authorMap.put("bio", author.getBio() != null ? author.getBio() : "");
+            authorMap.put("image", author.getImage() != null ? author.getImage() : "");
+            authorMap.put("following", false);
+        }
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("id", comment.id());
+        response.put("createdAt", comment.createdAt().toString());
+        response.put("updatedAt", comment.updatedAt().toString());
+        response.put("body", comment.body());
+        response.put("author", authorMap);
+        return response;
+    }
+
+    private Long getCurrentUserId(Authentication authentication) {
+        if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
+            return userId;
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/conduit/comment/adapter/out/persistence/CommentJpaEntity.java
+++ b/backend/src/main/java/com/conduit/comment/adapter/out/persistence/CommentJpaEntity.java
@@ -1,0 +1,33 @@
+package com.conduit.comment.adapter.out.persistence;
+
+import com.conduit.shared.config.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "comments")
+public class CommentJpaEntity extends BaseEntity {
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "article_id", nullable = false)
+    private Long articleId;
+
+    @Column(name = "author_id", nullable = false)
+    private Long authorId;
+
+    protected CommentJpaEntity() {}
+
+    public CommentJpaEntity(String body, Long articleId, Long authorId) {
+        this.body = body;
+        this.articleId = articleId;
+        this.authorId = authorId;
+    }
+
+    public String getBody() { return body; }
+    public Long getArticleId() { return articleId; }
+    public Long getAuthorId() { return authorId; }
+}

--- a/backend/src/main/java/com/conduit/comment/adapter/out/persistence/CommentJpaRepository.java
+++ b/backend/src/main/java/com/conduit/comment/adapter/out/persistence/CommentJpaRepository.java
@@ -1,0 +1,10 @@
+package com.conduit.comment.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentJpaRepository extends JpaRepository<CommentJpaEntity, Long> {
+
+    List<CommentJpaEntity> findByArticleIdOrderByCreatedAtDesc(Long articleId);
+}

--- a/backend/src/main/java/com/conduit/comment/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/comment/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -1,0 +1,55 @@
+package com.conduit.comment.adapter.out.persistence;
+
+import com.conduit.comment.domain.model.Comment;
+import com.conduit.comment.domain.port.out.CommentRepository;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class CommentPersistenceAdapter implements CommentRepository {
+
+    private final CommentJpaRepository jpaRepository;
+
+    public CommentPersistenceAdapter(CommentJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Comment save(Comment comment) {
+        var entity = new CommentJpaEntity(comment.body(), comment.articleId(), comment.authorId());
+        var saved = jpaRepository.save(entity);
+        return toComment(saved);
+    }
+
+    @Override
+    public List<Comment> findByArticleId(Long articleId) {
+        return jpaRepository.findByArticleIdOrderByCreatedAtDesc(articleId)
+                .stream()
+                .map(this::toComment)
+                .toList();
+    }
+
+    @Override
+    public Optional<Comment> findById(Long id) {
+        return jpaRepository.findById(id).map(this::toComment);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaRepository.deleteById(id);
+    }
+
+    private Comment toComment(CommentJpaEntity entity) {
+        return new Comment(
+                entity.getId(),
+                entity.getBody(),
+                entity.getArticleId(),
+                entity.getAuthorId(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/conduit/comment/application/service/CommentService.java
+++ b/backend/src/main/java/com/conduit/comment/application/service/CommentService.java
@@ -1,0 +1,63 @@
+package com.conduit.comment.application.service;
+
+import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.comment.domain.model.Comment;
+import com.conduit.comment.domain.port.in.AddCommentUseCase;
+import com.conduit.comment.domain.port.in.DeleteCommentUseCase;
+import com.conduit.comment.domain.port.in.ListCommentsUseCase;
+import com.conduit.comment.domain.port.out.CommentRepository;
+import com.conduit.shared.exception.ApiException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class CommentService implements AddCommentUseCase, ListCommentsUseCase, DeleteCommentUseCase {
+
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+
+    public CommentService(CommentRepository commentRepository, ArticleRepository articleRepository) {
+        this.commentRepository = commentRepository;
+        this.articleRepository = articleRepository;
+    }
+
+    @Override
+    @Transactional
+    public Comment addComment(String slug, String body, Long authorId) {
+        var article = articleRepository.findBySlug(slug)
+                .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
+
+        var comment = new Comment(null, body, article.getId(), authorId, Instant.now(), Instant.now());
+        return commentRepository.save(comment);
+    }
+
+    @Override
+    public List<Comment> listComments(String slug) {
+        var article = articleRepository.findBySlug(slug)
+                .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
+
+        return commentRepository.findByArticleId(article.getId());
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(String slug, Long commentId, Long currentUserId) {
+        // Verify article exists
+        articleRepository.findBySlug(slug)
+                .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
+
+        var comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ApiException.NotFoundException("Comment not found"));
+
+        if (!comment.authorId().equals(currentUserId)) {
+            throw new ApiException.ForbiddenException("You cannot delete this comment");
+        }
+
+        commentRepository.deleteById(commentId);
+    }
+}

--- a/backend/src/main/java/com/conduit/comment/domain/model/Comment.java
+++ b/backend/src/main/java/com/conduit/comment/domain/model/Comment.java
@@ -1,0 +1,12 @@
+package com.conduit.comment.domain.model;
+
+import java.time.Instant;
+
+public record Comment(
+        Long id,
+        String body,
+        Long articleId,
+        Long authorId,
+        Instant createdAt,
+        Instant updatedAt
+) {}

--- a/backend/src/main/java/com/conduit/comment/domain/port/in/AddCommentUseCase.java
+++ b/backend/src/main/java/com/conduit/comment/domain/port/in/AddCommentUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.comment.domain.port.in;
+
+import com.conduit.comment.domain.model.Comment;
+
+public interface AddCommentUseCase {
+
+    Comment addComment(String slug, String body, Long authorId);
+}

--- a/backend/src/main/java/com/conduit/comment/domain/port/in/DeleteCommentUseCase.java
+++ b/backend/src/main/java/com/conduit/comment/domain/port/in/DeleteCommentUseCase.java
@@ -1,0 +1,6 @@
+package com.conduit.comment.domain.port.in;
+
+public interface DeleteCommentUseCase {
+
+    void deleteComment(String slug, Long commentId, Long currentUserId);
+}

--- a/backend/src/main/java/com/conduit/comment/domain/port/in/ListCommentsUseCase.java
+++ b/backend/src/main/java/com/conduit/comment/domain/port/in/ListCommentsUseCase.java
@@ -1,0 +1,10 @@
+package com.conduit.comment.domain.port.in;
+
+import com.conduit.comment.domain.model.Comment;
+
+import java.util.List;
+
+public interface ListCommentsUseCase {
+
+    List<Comment> listComments(String slug);
+}

--- a/backend/src/main/java/com/conduit/comment/domain/port/out/CommentRepository.java
+++ b/backend/src/main/java/com/conduit/comment/domain/port/out/CommentRepository.java
@@ -1,0 +1,17 @@
+package com.conduit.comment.domain.port.out;
+
+import com.conduit.comment.domain.model.Comment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository {
+
+    Comment save(Comment comment);
+
+    List<Comment> findByArticleId(Long articleId);
+
+    Optional<Comment> findById(Long id);
+
+    void deleteById(Long id);
+}

--- a/backend/src/test/java/com/conduit/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/com/conduit/comment/CommentIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.conduit.comment;
+
+import com.conduit.article.adapter.out.persistence.ArticleJpaEntity;
+import com.conduit.article.adapter.out.persistence.ArticleJpaRepository;
+import com.conduit.shared.security.JwtTokenProvider;
+import com.conduit.user.adapter.out.persistence.UserJpaEntity;
+import com.conduit.user.adapter.out.persistence.UserJpaRepository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CommentIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserJpaRepository userRepository;
+    @Autowired private ArticleJpaRepository articleRepository;
+    @Autowired private JwtTokenProvider jwtTokenProvider;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private ObjectMapper objectMapper;
+
+    private String token1;
+    private String token2;
+    private String articleSlug;
+
+    @BeforeEach
+    void setUp() {
+        var user1 = userRepository.save(
+                new UserJpaEntity("author@test.com", "author", passwordEncoder.encode("pass"), null, null));
+        token1 = jwtTokenProvider.generateToken(user1.getId());
+
+        var user2 = userRepository.save(
+                new UserJpaEntity("other@test.com", "other", passwordEncoder.encode("pass"), null, null));
+        token2 = jwtTokenProvider.generateToken(user2.getId());
+
+        var article = articleRepository.save(
+                new ArticleJpaEntity("test-article", "Test Article", "desc", "body", user1.getId(), 0));
+        articleSlug = article.getSlug();
+    }
+
+    @Test
+    void addComment_returns200() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("comment", Map.of("body", "Nice article!")));
+
+        mockMvc.perform(post("/api/articles/{slug}/comments", articleSlug)
+                        .header("Authorization", "Token " + token1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.comment.body").value("Nice article!"))
+                .andExpect(jsonPath("$.comment.id").isNumber())
+                .andExpect(jsonPath("$.comment.author.username").value("author"));
+    }
+
+    @Test
+    void addComment_unauthenticated_returns401() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("comment", Map.of("body", "text")));
+
+        mockMvc.perform(post("/api/articles/{slug}/comments", articleSlug)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void listComments_returnsEmptyInitially() throws Exception {
+        mockMvc.perform(get("/api/articles/{slug}/comments", articleSlug))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.comments").isArray())
+                .andExpect(jsonPath("$.comments.length()").value(0));
+    }
+
+    @Test
+    void listComments_afterAdding_returnsComments() throws Exception {
+        // Add a comment
+        String body = objectMapper.writeValueAsString(
+                Map.of("comment", Map.of("body", "Comment 1")));
+        mockMvc.perform(post("/api/articles/{slug}/comments", articleSlug)
+                        .header("Authorization", "Token " + token1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // List
+        mockMvc.perform(get("/api/articles/{slug}/comments", articleSlug))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.comments.length()").value(1))
+                .andExpect(jsonPath("$.comments[0].body").value("Comment 1"))
+                .andExpect(jsonPath("$.comments[0].author.username").value("author"));
+    }
+
+    @Test
+    void deleteComment_byAuthor_returns200() throws Exception {
+        // Add comment
+        String body = objectMapper.writeValueAsString(
+                Map.of("comment", Map.of("body", "To delete")));
+        MvcResult result = mockMvc.perform(post("/api/articles/{slug}/comments", articleSlug)
+                        .header("Authorization", "Token " + token1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Integer commentId = objectMapper.readTree(result.getResponse().getContentAsString())
+                .path("comment").path("id").asInt();
+
+        // Delete
+        mockMvc.perform(delete("/api/articles/{slug}/comments/{id}", articleSlug, commentId)
+                        .header("Authorization", "Token " + token1))
+                .andExpect(status().isOk());
+
+        // Verify gone
+        mockMvc.perform(get("/api/articles/{slug}/comments", articleSlug))
+                .andExpect(jsonPath("$.comments.length()").value(0));
+    }
+
+    @Test
+    void deleteComment_byNonAuthor_returns403() throws Exception {
+        // Add comment as user1
+        String body = objectMapper.writeValueAsString(
+                Map.of("comment", Map.of("body", "Protected")));
+        MvcResult result = mockMvc.perform(post("/api/articles/{slug}/comments", articleSlug)
+                        .header("Authorization", "Token " + token1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Integer commentId = objectMapper.readTree(result.getResponse().getContentAsString())
+                .path("comment").path("id").asInt();
+
+        // Try delete as user2
+        mockMvc.perform(delete("/api/articles/{slug}/comments/{id}", articleSlug, commentId)
+                        .header("Authorization", "Token " + token2))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteComment_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(delete("/api/articles/{slug}/comments/1", articleSlug))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void addComment_articleNotFound_returns404() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("comment", Map.of("body", "text")));
+
+        mockMvc.perform(post("/api/articles/{slug}/comments", "nonexistent")
+                        .header("Authorization", "Token " + token1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/conduit/comment/application/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/conduit/comment/application/service/CommentServiceTest.java
@@ -1,0 +1,99 @@
+package com.conduit.comment.application.service;
+
+import com.conduit.article.domain.model.Article;
+import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.comment.domain.model.Comment;
+import com.conduit.comment.domain.port.out.CommentRepository;
+import com.conduit.shared.exception.ApiException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CommentServiceTest {
+
+    private CommentRepository commentRepository;
+    private ArticleRepository articleRepository;
+    private CommentService service;
+
+    private final Article article = new Article(
+            1L, "test-slug", "Test", "desc", "body", 10L, List.of(), 0, Instant.now(), Instant.now());
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        articleRepository = mock(ArticleRepository.class);
+        service = new CommentService(commentRepository, articleRepository);
+    }
+
+    @Test
+    void addComment_success() {
+        when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+        var saved = new Comment(1L, "Great article!", 1L, 5L, Instant.now(), Instant.now());
+        when(commentRepository.save(any())).thenReturn(saved);
+
+        Comment result = service.addComment("test-slug", "Great article!", 5L);
+
+        assertThat(result.body()).isEqualTo("Great article!");
+        verify(commentRepository).save(any());
+    }
+
+    @Test
+    void addComment_articleNotFound_throws() {
+        when(articleRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addComment("missing", "text", 1L))
+                .isInstanceOf(ApiException.NotFoundException.class);
+    }
+
+    @Test
+    void listComments_success() {
+        when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+        var c1 = new Comment(1L, "c1", 1L, 5L, Instant.now(), Instant.now());
+        var c2 = new Comment(2L, "c2", 1L, 6L, Instant.now(), Instant.now());
+        when(commentRepository.findByArticleId(1L)).thenReturn(List.of(c1, c2));
+
+        List<Comment> result = service.listComments("test-slug");
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void deleteComment_byAuthor_success() {
+        when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+        var comment = new Comment(1L, "text", 1L, 5L, Instant.now(), Instant.now());
+        when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
+
+        service.deleteComment("test-slug", 1L, 5L);
+
+        verify(commentRepository).deleteById(1L);
+    }
+
+    @Test
+    void deleteComment_notAuthor_throws403() {
+        when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+        var comment = new Comment(1L, "text", 1L, 5L, Instant.now(), Instant.now());
+        when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
+
+        assertThatThrownBy(() -> service.deleteComment("test-slug", 1L, 99L))
+                .isInstanceOf(ApiException.ForbiddenException.class);
+        verify(commentRepository, never()).deleteById(any());
+    }
+
+    @Test
+    void deleteComment_commentNotFound_throws() {
+        when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+        when(commentRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.deleteComment("test-slug", 999L, 5L))
+                .isInstanceOf(ApiException.NotFoundException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- `comment` 모듈 전체 구현 (Hexagonal Architecture): domain model, 3 use case ports, service, persistence adapter, REST controller
- `POST /api/articles/:slug/comments` — 댓글 추가 (인증 필수)
- `GET /api/articles/:slug/comments` — 댓글 목록 조회 (비인증 허용)
- `DELETE /api/articles/:slug/comments/:id` — 댓글 삭제 (작성자만 가능, 비작성자 403)
- 응답에 author profile (username, bio, image) 포함
- `CommentJpaEntity` extends `BaseEntity` — id, body, articleId, authorId, createdAt, updatedAt

## Test Plan

### 1. Unit (6건)
- CommentServiceTest: addComment 성공/아티클 미존재, listComments, deleteComment 성공/비작성자 403/댓글 미존재

### 2. Integration (8건)
- 댓글 추가 → 200 + body + author profile
- 비인증 댓글 추가 → 401
- 빈 댓글 목록 → []
- 댓글 추가 후 목록 → 1건 + author
- 작성자 댓글 삭제 → 200 + 목록 0건
- 비작성자 댓글 삭제 → 403
- 비인증 삭제 → 401
- 존재하지 않는 아티클 댓글 → 404

### 3. All Backend Tests
- BUILD SUCCESSFUL — 전체 테스트 통과

## Flow
- Mode: **add** (auto-detected)
- Issue: Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)