### PR TITLE
feat(backend): Favorite/Unfavorite 엔드포인트 + 멱등성

### DIFF
--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
@@ -3,9 +3,11 @@ package com.conduit.article.adapter.in.web;
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.in.CreateArticleUseCase;
 import com.conduit.article.domain.port.in.DeleteArticleUseCase;
+import com.conduit.article.domain.port.in.FavoriteArticleUseCase;
 import com.conduit.article.domain.port.in.FeedArticlesUseCase;
 import com.conduit.article.domain.port.in.GetArticleUseCase;
 import com.conduit.article.domain.port.in.ListArticlesUseCase;
+import com.conduit.article.domain.port.in.UnfavoriteArticleUseCase;
 import com.conduit.article.domain.port.in.UpdateArticleUseCase;
 import com.conduit.article.domain.port.out.FavoriteRepository;
 import com.conduit.article.domain.port.out.FollowRepository;
@@ -41,6 +43,8 @@ public class ArticleController {
   private final DeleteArticleUseCase deleteArticleUseCase;
   private final ListArticlesUseCase listArticlesUseCase;
   private final FeedArticlesUseCase feedArticlesUseCase;
+  private final FavoriteArticleUseCase favoriteArticleUseCase;
+  private final UnfavoriteArticleUseCase unfavoriteArticleUseCase;
   private final UserRepository userRepository;
   private final FavoriteRepository favoriteRepository;
   private final FollowRepository followRepository;
@@ -52,6 +56,8 @@ public class ArticleController {
       DeleteArticleUseCase deleteArticleUseCase,
       ListArticlesUseCase listArticlesUseCase,
       FeedArticlesUseCase feedArticlesUseCase,
+      FavoriteArticleUseCase favoriteArticleUseCase,
+      UnfavoriteArticleUseCase unfavoriteArticleUseCase,
       UserRepository userRepository,
       FavoriteRepository favoriteRepository,
       FollowRepository followRepository) {
@@ -61,6 +67,8 @@ public class ArticleController {
     this.deleteArticleUseCase = deleteArticleUseCase;
     this.listArticlesUseCase = listArticlesUseCase;
     this.feedArticlesUseCase = feedArticlesUseCase;
+    this.favoriteArticleUseCase = favoriteArticleUseCase;
+    this.unfavoriteArticleUseCase = unfavoriteArticleUseCase;
     this.userRepository = userRepository;
     this.favoriteRepository = favoriteRepository;
     this.followRepository = followRepository;
@@ -138,6 +146,26 @@ public class ArticleController {
     Long userId = (Long) authentication.getPrincipal();
     deleteArticleUseCase.delete(slug, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/articles/{slug}/favorite")
+  public ResponseEntity<Map<String, ArticleResponse>> favoriteArticle(
+      Authentication authentication, @PathVariable String slug) {
+    Long userId = (Long) authentication.getPrincipal();
+    Article article = favoriteArticleUseCase.favorite(slug, userId);
+    User author = findAuthor(article.getAuthorId());
+    boolean isFollowing = followRepository.existsByFollowerIdAndFolloweeId(userId, article.getAuthorId());
+    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author, true, isFollowing)));
+  }
+
+  @DeleteMapping("/articles/{slug}/favorite")
+  public ResponseEntity<Map<String, ArticleResponse>> unfavoriteArticle(
+      Authentication authentication, @PathVariable String slug) {
+    Long userId = (Long) authentication.getPrincipal();
+    Article article = unfavoriteArticleUseCase.unfavorite(slug, userId);
+    User author = findAuthor(article.getAuthorId());
+    boolean isFollowing = followRepository.existsByFollowerIdAndFolloweeId(userId, article.getAuthorId());
+    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author, false, isFollowing)));
   }
 
   private List<ArticleResponse> buildArticleResponses(List<Article> articles, Long currentUserId) {

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteJpaRepository.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoriteJpaRepository.java
@@ -12,4 +12,6 @@ public interface FavoriteJpaRepository extends JpaRepository<FavoriteJpaEntity, 
   @Query("SELECT f.articleId FROM FavoriteJpaEntity f WHERE f.userId = :userId AND f.articleId IN :articleIds")
   List<Long> findArticleIdsByUserIdAndArticleIdIn(
       @Param("userId") Long userId, @Param("articleIds") List<Long> articleIds);
+
+  int countByArticleId(Long articleId);
 }

--- a/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoritePersistenceAdapter.java
+++ b/backend/src/main/java/com/conduit/article/adapter/out/persistence/FavoritePersistenceAdapter.java
@@ -28,4 +28,22 @@ public class FavoritePersistenceAdapter implements FavoriteRepository {
     return new HashSet<>(
         favoriteJpaRepository.findArticleIdsByUserIdAndArticleIdIn(userId, articleIds));
   }
+
+  @Override
+  public void save(Long userId, Long articleId) {
+    favoriteJpaRepository.save(new FavoriteJpaEntity(userId, articleId));
+  }
+
+  @Override
+  public void delete(Long userId, Long articleId) {
+    FavoriteId id = new FavoriteId(userId, articleId);
+    if (favoriteJpaRepository.existsById(id)) {
+      favoriteJpaRepository.deleteById(id);
+    }
+  }
+
+  @Override
+  public int countByArticleId(Long articleId) {
+    return favoriteJpaRepository.countByArticleId(articleId);
+  }
 }

--- a/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
+++ b/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
@@ -3,11 +3,14 @@ package com.conduit.article.application.service;
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.in.CreateArticleUseCase;
 import com.conduit.article.domain.port.in.DeleteArticleUseCase;
+import com.conduit.article.domain.port.in.FavoriteArticleUseCase;
 import com.conduit.article.domain.port.in.FeedArticlesUseCase;
 import com.conduit.article.domain.port.in.GetArticleUseCase;
 import com.conduit.article.domain.port.in.ListArticlesUseCase;
+import com.conduit.article.domain.port.in.UnfavoriteArticleUseCase;
 import com.conduit.article.domain.port.in.UpdateArticleUseCase;
 import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.article.domain.port.out.FavoriteRepository;
 import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import java.util.List;
@@ -22,14 +25,19 @@ public class ArticleService
         UpdateArticleUseCase,
         DeleteArticleUseCase,
         ListArticlesUseCase,
-        FeedArticlesUseCase {
+        FeedArticlesUseCase,
+        FavoriteArticleUseCase,
+        UnfavoriteArticleUseCase {
 
   private final ArticleRepository articleRepository;
   private final FollowRepository followRepository;
+  private final FavoriteRepository favoriteRepository;
 
-  public ArticleService(ArticleRepository articleRepository, FollowRepository followRepository) {
+  public ArticleService(ArticleRepository articleRepository, FollowRepository followRepository,
+      FavoriteRepository favoriteRepository) {
     this.articleRepository = articleRepository;
     this.followRepository = followRepository;
+    this.favoriteRepository = favoriteRepository;
   }
 
   @Override
@@ -129,5 +137,33 @@ public class ArticleService
       return 0;
     }
     return articleRepository.countByAuthorIds(followeeIds);
+  }
+
+  @Override
+  public Article favorite(String slug, Long userId) {
+    Article article =
+        articleRepository
+            .findBySlug(slug)
+            .orElseThrow(() -> new ApiException.NotFoundException("article not found"));
+
+    if (!favoriteRepository.existsByUserIdAndArticleId(userId, article.getId())) {
+      favoriteRepository.save(userId, article.getId());
+    }
+
+    article.setFavoritesCount(favoriteRepository.countByArticleId(article.getId()));
+    return articleRepository.save(article);
+  }
+
+  @Override
+  public Article unfavorite(String slug, Long userId) {
+    Article article =
+        articleRepository
+            .findBySlug(slug)
+            .orElseThrow(() -> new ApiException.NotFoundException("article not found"));
+
+    favoriteRepository.delete(userId, article.getId());
+
+    article.setFavoritesCount(favoriteRepository.countByArticleId(article.getId()));
+    return articleRepository.save(article);
   }
 }

--- a/backend/src/main/java/com/conduit/article/domain/model/Article.java
+++ b/backend/src/main/java/com/conduit/article/domain/model/Article.java
@@ -112,6 +112,10 @@ public class Article {
     return favoritesCount;
   }
 
+  public void setFavoritesCount(int favoritesCount) {
+    this.favoritesCount = favoritesCount;
+  }
+
   public Instant getCreatedAt() {
     return createdAt;
   }

--- a/backend/src/main/java/com/conduit/article/domain/port/in/FavoriteArticleUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/FavoriteArticleUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+
+public interface FavoriteArticleUseCase {
+
+    Article favorite(String slug, Long userId);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/in/UnfavoriteArticleUseCase.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/in/UnfavoriteArticleUseCase.java
@@ -1,0 +1,8 @@
+package com.conduit.article.domain.port.in;
+
+import com.conduit.article.domain.model.Article;
+
+public interface UnfavoriteArticleUseCase {
+
+    Article unfavorite(String slug, Long userId);
+}

--- a/backend/src/main/java/com/conduit/article/domain/port/out/FavoriteRepository.java
+++ b/backend/src/main/java/com/conduit/article/domain/port/out/FavoriteRepository.java
@@ -8,4 +8,10 @@ public interface FavoriteRepository {
   boolean existsByUserIdAndArticleId(Long userId, Long articleId);
 
   Set<Long> findFavoritedArticleIds(Long userId, List<Long> articleIds);
+
+  void save(Long userId, Long articleId);
+
+  void delete(Long userId, Long articleId);
+
+  int countByArticleId(Long articleId);
 }

--- a/backend/src/test/java/com/conduit/article/adapter/in/web/ArticleControllerTest.java
+++ b/backend/src/test/java/com/conduit/article/adapter/in/web/ArticleControllerTest.java
@@ -286,4 +286,147 @@ class ArticleControllerTest {
           .andExpect(status().isNotFound());
     }
   }
+
+  @Nested
+  @DisplayName("POST /api/articles/{slug}/favorite")
+  class FavoriteArticle {
+
+    @Test
+    @DisplayName("should favorite article and return updated count")
+    void success() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "Fav Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              post("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.slug").value(slug))
+          .andExpect(jsonPath("$.article.favorited").value(true))
+          .andExpect(jsonPath("$.article.favoritesCount").value(1));
+    }
+
+    @Test
+    @DisplayName("should be idempotent - favoriting twice returns same count")
+    void idempotent() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "Fav Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              post("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.favoritesCount").value(1));
+
+      mockMvc
+          .perform(
+              post("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.favoritesCount").value(1));
+    }
+
+    @Test
+    @DisplayName("should return 401 without authentication")
+    void unauthorized() throws Exception {
+      mockMvc
+          .perform(post("/api/articles/some-slug/favorite"))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should return 404 for nonexistent article")
+    void notFound() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+
+      mockMvc
+          .perform(
+              post("/api/articles/nonexistent/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /api/articles/{slug}/favorite")
+  class UnfavoriteArticle {
+
+    @Test
+    @DisplayName("should unfavorite article and return updated count")
+    void success() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "Unfav Article", "Desc", "Body", "");
+
+      // Favorite first
+      mockMvc
+          .perform(
+              post("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isOk());
+
+      // Unfavorite
+      mockMvc
+          .perform(
+              delete("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.slug").value(slug))
+          .andExpect(jsonPath("$.article.favorited").value(false))
+          .andExpect(jsonPath("$.article.favoritesCount").value(0));
+    }
+
+    @Test
+    @DisplayName("should be safe to unfavorite when not favorited")
+    void idempotent() throws Exception {
+      String token = registerAndGetToken("jacob", "jake@jake.com", "jakejake1");
+      String slug = createArticle(token, "Never Fav Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              delete("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.favoritesCount").value(0));
+    }
+
+    @Test
+    @DisplayName("should return 401 without authentication")
+    void unauthorized() throws Exception {
+      mockMvc
+          .perform(delete("/api/articles/some-slug/favorite"))
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should track multiple users favoriting same article")
+    void multipleUsers() throws Exception {
+      String token1 = registerAndGetToken("user1", "user1@test.com", "password123");
+      String token2 = registerAndGetToken("user2", "user2@test.com", "password123");
+      String slug = createArticle(token1, "Popular Article", "Desc", "Body", "");
+
+      mockMvc
+          .perform(
+              post("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token1))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.favoritesCount").value(1));
+
+      mockMvc
+          .perform(
+              post("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token2))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.favoritesCount").value(2));
+
+      // User 1 unfavorites
+      mockMvc
+          .perform(
+              delete("/api/articles/" + slug + "/favorite")
+                  .header("Authorization", "Token " + token1))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.article.favoritesCount").value(1));
+    }
+  }
 }

--- a/backend/src/test/java/com/conduit/article/application/service/ArticleServiceTest.java
+++ b/backend/src/test/java/com/conduit/article/application/service/ArticleServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.conduit.article.domain.model.Article;
 import com.conduit.article.domain.port.out.ArticleRepository;
+import com.conduit.article.domain.port.out.FavoriteRepository;
 import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import java.time.Instant;
@@ -28,11 +29,12 @@ class ArticleServiceTest {
 
   @Mock private ArticleRepository articleRepository;
   @Mock private FollowRepository followRepository;
+  @Mock private FavoriteRepository favoriteRepository;
   private ArticleService articleService;
 
   @BeforeEach
   void setUp() {
-    articleService = new ArticleService(articleRepository, followRepository);
+    articleService = new ArticleService(articleRepository, followRepository, favoriteRepository);
   }
 
   @Nested
@@ -293,6 +295,87 @@ class ArticleServiceTest {
       assertThatThrownBy(() -> articleService.delete("nonexistent", 1L))
           .isInstanceOf(ApiException.NotFoundException.class)
           .hasMessageContaining("article not found");
+    }
+  }
+
+  @Nested
+  @DisplayName("favorite")
+  class Favorite {
+
+    @Test
+    @DisplayName("should favorite article and update count")
+    void success() {
+      Article article =
+          new Article(
+              1L, "test-slug", "Title", "Desc", "Body", 2L, List.of(), 0, Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+      when(favoriteRepository.existsByUserIdAndArticleId(10L, 1L)).thenReturn(false);
+      when(favoriteRepository.countByArticleId(1L)).thenReturn(1);
+      when(articleRepository.save(any(Article.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      Article result = articleService.favorite("test-slug", 10L);
+
+      verify(favoriteRepository).save(10L, 1L);
+      assertThat(result.getFavoritesCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should be idempotent - not duplicate favorite")
+    void idempotent() {
+      Article article =
+          new Article(
+              1L, "test-slug", "Title", "Desc", "Body", 2L, List.of(), 1, Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+      when(favoriteRepository.existsByUserIdAndArticleId(10L, 1L)).thenReturn(true);
+      when(favoriteRepository.countByArticleId(1L)).thenReturn(1);
+      when(articleRepository.save(any(Article.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      Article result = articleService.favorite("test-slug", 10L);
+
+      verify(favoriteRepository, never()).save(any(), any());
+      assertThat(result.getFavoritesCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException when article not found")
+    void notFound() {
+      when(articleRepository.findBySlug("nonexistent")).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> articleService.favorite("nonexistent", 10L))
+          .isInstanceOf(ApiException.NotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("unfavorite")
+  class Unfavorite {
+
+    @Test
+    @DisplayName("should unfavorite article and update count")
+    void success() {
+      Article article =
+          new Article(
+              1L, "test-slug", "Title", "Desc", "Body", 2L, List.of(), 1, Instant.now(),
+              Instant.now());
+      when(articleRepository.findBySlug("test-slug")).thenReturn(Optional.of(article));
+      when(favoriteRepository.countByArticleId(1L)).thenReturn(0);
+      when(articleRepository.save(any(Article.class))).thenAnswer(inv -> inv.getArgument(0));
+
+      Article result = articleService.unfavorite("test-slug", 10L);
+
+      verify(favoriteRepository).delete(10L, 1L);
+      assertThat(result.getFavoritesCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException when article not found")
+    void notFound() {
+      when(articleRepository.findBySlug("nonexistent")).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> articleService.unfavorite("nonexistent", 10L))
+          .isInstanceOf(ApiException.NotFoundException.class);
     }
   }
 }


### PR DESCRIPTION
## Summary
- POST/DELETE `/api/articles/:slug/favorite` 엔드포인트 추가
- Favorite 멱등성 보장 (중복 favorite 시 count 유지)
- Unfavorite 안전 무시 (미존재 시 에러 없음)
- favoritesCount 실시간 count 쿼리 기반 갱신

## Test Plan
- [x] Unit: ArticleServiceTest — favorite/unfavorite 5개 케이스 (성공, 멱등, 404)
- [x] Integration: ArticleControllerTest — favorite/unfavorite 7개 케이스 (성공, 멱등, 401, 404, 다중 사용자)
- [x] `./gradlew test` BUILD SUCCESSFUL

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)