### PR TITLE
feat(frontend): Profile 페이지 — 배너/탭/Follow 버튼

### DIFF
--- a/frontend/e2e/profile-page.spec.ts
+++ b/frontend/e2e/profile-page.spec.ts
@@ -1,0 +1,300 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE = "http://localhost:5174";
+const API = "http://localhost:8080/api";
+
+let userCounter = 0;
+function uniqueUser() {
+  userCounter++;
+  const ts = Date.now();
+  return {
+    username: `profuser${userCounter}${ts}`,
+    email: `profuser${userCounter}${ts}@test.com`,
+    password: "password123",
+  };
+}
+
+async function registerApi(user: {
+  username: string;
+  email: string;
+  password: string;
+}) {
+  const res = await fetch(`${API}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user }),
+  });
+  const data = await res.json();
+  return data.user.token as string;
+}
+
+async function createArticleApi(
+  token: string,
+  title: string,
+  tags: string[] = [],
+) {
+  const res = await fetch(`${API}/articles`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token}`,
+    },
+    body: JSON.stringify({
+      article: {
+        title,
+        description: `Description for ${title}`,
+        body: `Body for ${title}`,
+        tagList: tags,
+      },
+    }),
+  });
+  const data = await res.json();
+  return data.article.slug as string;
+}
+
+async function favoriteArticleApi(token: string, slug: string) {
+  await fetch(`${API}/articles/${slug}/favorite`, {
+    method: "POST",
+    headers: { Authorization: `Token ${token}` },
+  });
+}
+
+async function followUserApi(token: string, username: string) {
+  await fetch(`${API}/profiles/${username}/follow`, {
+    method: "POST",
+    headers: { Authorization: `Token ${token}` },
+  });
+}
+
+async function loginInBrowser(
+  page: Page,
+  email: string,
+  token: string,
+  username: string,
+) {
+  // Navigate first to have a valid origin for localStorage
+  await page.goto(`${BASE}/`);
+  await page.evaluate(
+    ({ token, user }) => {
+      localStorage.setItem("conduit_token", token);
+      localStorage.setItem("conduit_user", JSON.stringify(user));
+    },
+    {
+      token,
+      user: { email, token, username, bio: null, image: null },
+    },
+  );
+}
+
+test.describe("Profile Page", () => {
+  test("should show profile banner with username and image", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    await registerApi(user);
+
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await expect(page.locator("h4")).toContainText(user.username);
+    await expect(page.locator("img").first()).toBeVisible();
+  });
+
+  test("should show 'My Articles' tab with user's articles", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    await createArticleApi(token, `Profile Article One ${Date.now()}`);
+    await createArticleApi(token, `Profile Article Two ${Date.now()}`);
+
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await expect(page.getByText("My Articles")).toBeVisible();
+
+    // Wait for articles to load
+    await expect(
+      page.locator('[class*="articlePreview"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+    const articles = page.locator('[class*="articlePreview"]');
+    await expect(articles).toHaveCount(2);
+  });
+
+  test("should show 'Favorited Articles' tab with favorited articles", async ({
+    page,
+  }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    const slug = await createArticleApi(
+      authorToken,
+      `Fav Target ${Date.now()}`,
+    );
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+    await favoriteArticleApi(viewerToken, slug);
+
+    await page.goto(`${BASE}/#/profile/${viewer.username}/favorites`);
+    await expect(page.getByText("Favorited Articles")).toBeVisible();
+
+    await expect(
+      page.locator('[class*="articlePreview"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+    const articles = page.locator('[class*="articlePreview"]');
+    await expect(articles).toHaveCount(1);
+  });
+
+  test("should show 'Edit Profile Settings' button on own profile", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await page.reload();
+
+    await expect(page.getByText("Edit Profile Settings")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("should show Follow/Unfollow button on other user's profile", async ({
+    page,
+  }) => {
+    const other = uniqueUser();
+    await registerApi(other);
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+    await page.goto(`${BASE}/#/profile/${other.username}`);
+    await page.reload();
+
+    const followBtn = page.getByText(`Follow ${other.username}`, {
+      exact: false,
+    });
+    await expect(followBtn).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should toggle Follow/Unfollow on click", async ({ page }) => {
+    const other = uniqueUser();
+    await registerApi(other);
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+    await page.goto(`${BASE}/#/profile/${other.username}`);
+    await page.reload();
+
+    // Click Follow
+    const followBtn = page.getByText(`Follow ${other.username}`, {
+      exact: false,
+    });
+    await expect(followBtn).toBeVisible({ timeout: 10000 });
+    await followBtn.click();
+
+    // Should now show Unfollow
+    await expect(
+      page.getByText(`Unfollow ${other.username}`, { exact: false }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Click Unfollow
+    await page
+      .getByText(`Unfollow ${other.username}`, { exact: false })
+      .click();
+
+    // Should show Follow again
+    await expect(
+      page.getByText(`Follow ${other.username}`, { exact: false }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should not show Follow button when not authenticated", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    await registerApi(user);
+
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await expect(page.locator("h4")).toContainText(user.username);
+
+    // No follow button for unauthenticated user
+    await expect(
+      page.getByText("Follow", { exact: false }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByText("Edit Profile Settings"),
+    ).not.toBeVisible();
+  });
+
+  test("should switch between My Articles and Favorited Articles tabs", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    await createArticleApi(token, `My Own Article ${Date.now()}`);
+
+    // Create an article by another user and favorite it
+    const other = uniqueUser();
+    const otherToken = await registerApi(other);
+    const slug = await createArticleApi(
+      otherToken,
+      `Other Fav Article ${Date.now()}`,
+    );
+    await favoriteArticleApi(token, slug);
+
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+
+    // My Articles tab should show 1 article
+    await expect(
+      page.locator('[class*="articlePreview"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    const myArticles = page.locator('[class*="articlePreview"]');
+    await expect(myArticles).toHaveCount(1);
+
+    // Click Favorited Articles tab
+    await page.getByText("Favorited Articles").click();
+    await page.waitForURL(/\/favorites/);
+
+    await expect(
+      page.locator('[class*="articlePreview"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+    const favArticles = page.locator('[class*="articlePreview"]');
+    await expect(favArticles).toHaveCount(1);
+  });
+
+  test("should show empty message when no articles", async ({ page }) => {
+    const user = uniqueUser();
+    await registerApi(user);
+
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await expect(
+      page.getByText("No articles are here... yet."),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should show User not found for nonexistent profile", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/#/profile/nonexistent_user_xyz`);
+    await expect(page.getByText("User not found.")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("should navigate to article from profile", async ({ page }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    await createArticleApi(token, `Clickable Article ${Date.now()}`);
+
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await expect(
+      page.locator('[class*="articlePreview"]').first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Click on the article preview title/link
+    await page.locator('[class*="previewLink"]').first().click();
+    await expect(page).toHaveURL(/article/);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30000,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:5174",
+    headless: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -22,6 +22,9 @@ dependencies:
     version: 6.30.3(react-dom@18.3.1)(react@18.3.1)
 
 devDependencies:
+  '@playwright/test':
+    specifier: ^1.60.0
+    version: 1.60.0
   '@types/react':
     specifier: ^18.3.12
     version: 18.3.28
@@ -451,6 +454,14 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
+  /@playwright/test@1.60.0:
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.60.0
     dev: true
 
   /@remix-run/router@1.23.2:
@@ -914,6 +925,14 @@ packages:
       mime-types: 2.1.35
     dev: false
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1055,6 +1074,22 @@ packages:
 
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
+
+  /playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /postcss@8.5.14:

--- a/frontend/src/api/profiles.ts
+++ b/frontend/src/api/profiles.ts
@@ -1,0 +1,33 @@
+import apiClient from "./client";
+
+export interface Profile {
+  username: string;
+  bio: string | null;
+  image: string | null;
+  following: boolean;
+}
+
+interface ProfileResponse {
+  profile: Profile;
+}
+
+export async function getProfileApi(username: string): Promise<Profile> {
+  const { data } = await apiClient.get<ProfileResponse>(
+    `/profiles/${username}`,
+  );
+  return data.profile;
+}
+
+export async function followUserApi(username: string): Promise<Profile> {
+  const { data } = await apiClient.post<ProfileResponse>(
+    `/profiles/${username}/follow`,
+  );
+  return data.profile;
+}
+
+export async function unfollowUserApi(username: string): Promise<Profile> {
+  const { data } = await apiClient.delete<ProfileResponse>(
+    `/profiles/${username}/follow`,
+  );
+  return data.profile;
+}

--- a/frontend/src/pages/profile-page.module.css
+++ b/frontend/src/pages/profile-page.module.css
@@ -1,0 +1,257 @@
+.userBanner {
+  background: #333;
+  padding: 2rem 0 1rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.userImage {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+  object-fit: cover;
+}
+
+.username {
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.userBio {
+  color: #aaa;
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+  font-weight: 300;
+  max-width: 450px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.actionBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.2rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.editSettingsBtn {
+  composes: actionBtn;
+  color: #999;
+  border: 1px solid #999;
+  background: transparent;
+}
+
+.editSettingsBtn:hover {
+  color: #fff;
+  background: #999;
+}
+
+.followBtn {
+  composes: actionBtn;
+  color: #999;
+  border: 1px solid #999;
+  background: transparent;
+}
+
+.followBtn:hover {
+  color: #fff;
+  background: #999;
+}
+
+.unfollowBtn {
+  composes: actionBtn;
+  color: #fff;
+  border: 1px solid #5cb85c;
+  background: #5cb85c;
+}
+
+.unfollowBtn:hover {
+  background: #449d44;
+  border-color: #449d44;
+}
+
+/* Feed Tabs */
+.feedToggle {
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 1rem;
+}
+
+.feedToggle ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+}
+
+.tabItem {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.5rem 1rem;
+  color: #aaa;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.tabItem:hover {
+  color: #5cb85c;
+}
+
+.tabItemActive {
+  composes: tabItem;
+  color: #5cb85c;
+  border-bottom: 2px solid #5cb85c;
+}
+
+/* Article Preview (reuse from home) */
+.articlePreview {
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 1.5rem 0;
+}
+
+.articleMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.authorImage {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.authorInfo {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.authorName {
+  color: #5cb85c;
+  font-weight: 500;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.authorName:hover {
+  text-decoration: underline;
+}
+
+.articleDate {
+  color: #bbb;
+  font-size: 0.8rem;
+  font-weight: 300;
+}
+
+.favCount {
+  color: #5cb85c;
+  border: 1px solid #5cb85c;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.2rem;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.previewLink {
+  text-decoration: none;
+  display: block;
+}
+
+.previewTitle {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+  color: #373a3c;
+}
+
+.previewDescription {
+  color: #999;
+  font-weight: 300;
+  font-size: 0.95rem;
+  margin: 0 0 0.75rem;
+  line-height: 1.3;
+}
+
+.readMore {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.readMoreText {
+  color: #bbb;
+  font-size: 0.8rem;
+}
+
+.previewTagList {
+  list-style: none;
+  display: flex;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.previewTag {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid #ddd;
+  color: #aaa;
+  border-radius: 10rem;
+}
+
+/* Pagination */
+.pagination {
+  list-style: none;
+  display: flex;
+  gap: 0;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.pageItem {
+  border: 1px solid #ddd;
+  margin-left: -1px;
+}
+
+.pageItemActive {
+  composes: pageItem;
+  background: #5cb85c;
+}
+
+.pageItemActive .pageLink {
+  color: #fff;
+}
+
+.pageLink {
+  display: block;
+  padding: 0.35rem 0.75rem;
+  color: #5cb85c;
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.pageLink:hover {
+  background: #eceeef;
+}
+
+.loadingMessage {
+  padding: 1.5rem 0;
+  font-size: 1rem;
+  color: #999;
+}

--- a/frontend/src/pages/profile-page.tsx
+++ b/frontend/src/pages/profile-page.tsx
@@ -1,22 +1,257 @@
-import { useParams } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useParams, useLocation, Link } from "react-router-dom";
+import { useAuth } from "@/hooks/use-auth";
+import { getProfileApi, followUserApi, unfollowUserApi } from "@/api/profiles";
+import type { Profile } from "@/api/profiles";
+import { listArticlesApi, type Article } from "@/api/articles";
+import styles from "./profile-page.module.css";
+
+const ARTICLES_PER_PAGE = 10;
+const DEFAULT_IMAGE = "https://api.realworld.io/images/smiley-cyrus.jpeg";
+
+type TabType = "my" | "favorited";
 
 function ProfilePage() {
   const { username } = useParams<{ username: string }>();
+  const location = useLocation();
+  const { user, isAuthenticated } = useAuth();
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [articlesCount, setArticlesCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [articlesLoading, setArticlesLoading] = useState(true);
+  const [followLoading, setFollowLoading] = useState(false);
+
+  const isFavoritesRoute = location.pathname.endsWith("/favorites");
+  const activeTab: TabType = isFavoritesRoute ? "favorited" : "my";
+  const isOwnProfile = user?.username === username;
+
+  // Load profile
+  useEffect(() => {
+    if (!username) return;
+    setLoading(true);
+    getProfileApi(username)
+      .then(setProfile)
+      .catch(() => setProfile(null))
+      .finally(() => setLoading(false));
+  }, [username]);
+
+  // Load articles on tab/page change
+  useEffect(() => {
+    if (!username) return;
+    setArticlesLoading(true);
+    const offset = (currentPage - 1) * ARTICLES_PER_PAGE;
+    const params =
+      activeTab === "favorited"
+        ? { favorited: username, limit: ARTICLES_PER_PAGE, offset }
+        : { author: username, limit: ARTICLES_PER_PAGE, offset };
+
+    listArticlesApi(params)
+      .then((res) => {
+        setArticles(res.articles);
+        setArticlesCount(res.articlesCount);
+      })
+      .catch(() => {
+        setArticles([]);
+        setArticlesCount(0);
+      })
+      .finally(() => setArticlesLoading(false));
+  }, [username, activeTab, currentPage]);
+
+  // Reset page on tab change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [activeTab]);
+
+  async function handleFollowToggle() {
+    if (!username || !profile || followLoading) return;
+    setFollowLoading(true);
+    try {
+      const updated = profile.following
+        ? await unfollowUserApi(username)
+        : await followUserApi(username);
+      setProfile(updated);
+    } catch {
+      // ignore
+    } finally {
+      setFollowLoading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="profile-page">
+        <div className="container page">
+          <p>Loading profile...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="profile-page">
+        <div className="container page">
+          <p>User not found.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(articlesCount / ARTICLES_PER_PAGE);
 
   return (
     <div className="profile-page">
-      <div className="user-info">
+      {/* User Banner */}
+      <div className={styles.userBanner}>
         <div className="container">
-          <div className="row">
-            <div className="col-xs-12 col-md-10 offset-md-1">
-              <h4>{username}</h4>
-              <p className="text-muted">
-                Profile will be implemented in Sprint 3.
-              </p>
+          <img
+            className={styles.userImage}
+            src={profile.image || DEFAULT_IMAGE}
+            alt={profile.username}
+          />
+          <h4 className={styles.username}>{profile.username}</h4>
+          {profile.bio && <p className={styles.userBio}>{profile.bio}</p>}
+          {isOwnProfile ? (
+            <Link to="/settings" className={styles.editSettingsBtn}>
+              ⚙ Edit Profile Settings
+            </Link>
+          ) : (
+            isAuthenticated && (
+              <button
+                className={
+                  profile.following ? styles.unfollowBtn : styles.followBtn
+                }
+                onClick={handleFollowToggle}
+                disabled={followLoading}
+              >
+                {profile.following
+                  ? `✓ Unfollow ${profile.username}`
+                  : `+ Follow ${profile.username}`}
+              </button>
+            )
+          )}
+        </div>
+      </div>
+
+      <div className="container page">
+        <div className="row">
+          <div className="col-md-10 offset-md-1">
+            {/* Feed Tabs */}
+            <div className={styles.feedToggle}>
+              <ul>
+                <li>
+                  <Link
+                    to={`/profile/${username}`}
+                    className={
+                      activeTab === "my"
+                        ? styles.tabItemActive
+                        : styles.tabItem
+                    }
+                  >
+                    My Articles
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to={`/profile/${username}/favorites`}
+                    className={
+                      activeTab === "favorited"
+                        ? styles.tabItemActive
+                        : styles.tabItem
+                    }
+                  >
+                    Favorited Articles
+                  </Link>
+                </li>
+              </ul>
             </div>
+
+            {/* Articles */}
+            {articlesLoading ? (
+              <p className={styles.loadingMessage}>Loading articles...</p>
+            ) : articles.length === 0 ? (
+              <p className={styles.loadingMessage}>
+                No articles are here... yet.
+              </p>
+            ) : (
+              articles.map((article) => (
+                <ArticlePreview key={article.slug} article={article} />
+              ))
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <ul className={styles.pagination}>
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map(
+                  (page) => (
+                    <li
+                      key={page}
+                      className={`${styles.pageItem} ${page === currentPage ? styles.pageItemActive : ""}`}
+                    >
+                      <button
+                        className={styles.pageLink}
+                        onClick={() => setCurrentPage(page)}
+                      >
+                        {page}
+                      </button>
+                    </li>
+                  ),
+                )}
+              </ul>
+            )}
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function ArticlePreview({ article }: { article: Article }) {
+  const formattedDate = new Date(article.createdAt).toLocaleDateString(
+    "en-US",
+    { year: "numeric", month: "long", day: "numeric" },
+  );
+
+  return (
+    <div className={styles.articlePreview}>
+      <div className={styles.articleMeta}>
+        <Link to={`/profile/${article.author.username}`}>
+          <img
+            className={styles.authorImage}
+            src={article.author.image || DEFAULT_IMAGE}
+            alt={article.author.username}
+          />
+        </Link>
+        <div className={styles.authorInfo}>
+          <Link
+            to={`/profile/${article.author.username}`}
+            className={styles.authorName}
+          >
+            {article.author.username}
+          </Link>
+          <span className={styles.articleDate}>{formattedDate}</span>
+        </div>
+        <span className={styles.favCount}>♥ {article.favoritesCount}</span>
+      </div>
+      <Link to={`/article/${article.slug}`} className={styles.previewLink}>
+        <h2 className={styles.previewTitle}>{article.title}</h2>
+        <p className={styles.previewDescription}>{article.description}</p>
+        <div className={styles.readMore}>
+          <span className={styles.readMoreText}>Read more...</span>
+          {article.tagList.length > 0 && (
+            <ul className={styles.previewTagList}>
+              {article.tagList.map((tag) => (
+                <li key={tag} className={styles.previewTag}>
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `ProfilePage` 컴포넌트 구현: 사용자 배너(image, username, bio) + 다크 배경
- **My Articles** / **Favorited Articles** 탭 전환 (`/profile/:username`, `/profile/:username/favorites`)
- 본인 프로필: "Edit Profile Settings" 버튼 → `/#/settings`
- 타인 프로필 + 인증: Follow/Unfollow 버튼 토글
- `profiles.ts` API 모듈: `getProfileApi`, `followUserApi`, `unfollowUserApi`
- `ArticlePreview` 컴포넌트 재사용 + 페이지네이션
- CSS Modules 스타일 적용
- Playwright + 테스트 인프라 추가 (`@playwright/test`, `playwright.config.ts`)

## Test Plan
- [x] E2E: 11개 테스트 전부 PASS (배너 표시, My Articles, Favorited Articles, Edit Settings, Follow/Unfollow 토글, 미인증 제한, 탭 전환, 빈 목록, 404, 아티클 네비게이션)
- [x] TypeScript: `tsc --noEmit` 클린 컴파일
- [x] 스크린샷: 4장 캡처 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)