### PR TITLE
feat(frontend): 댓글 섹션 — 입력 폼 + 댓글 카드 + 삭제 #21

### DIFF
--- a/frontend/e2e/comment-section.spec.ts
+++ b/frontend/e2e/comment-section.spec.ts
@@ -1,0 +1,270 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE = "http://localhost:5174";
+const API = "http://localhost:8080/api";
+
+let userCounter = 0;
+function uniqueUser() {
+  userCounter++;
+  const ts = Date.now();
+  return {
+    username: `cmtuser${userCounter}${ts}`,
+    email: `cmtuser${userCounter}${ts}@test.com`,
+    password: "password123",
+  };
+}
+
+async function registerApi(user: {
+  username: string;
+  email: string;
+  password: string;
+}) {
+  const res = await fetch(`${API}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user }),
+  });
+  const data = await res.json();
+  return data.user.token as string;
+}
+
+async function createArticleApi(token: string, title: string) {
+  const res = await fetch(`${API}/articles`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token}`,
+    },
+    body: JSON.stringify({
+      article: {
+        title,
+        description: `Description for ${title}`,
+        body: `Body for ${title}`,
+        tagList: [],
+      },
+    }),
+  });
+  const data = await res.json();
+  return data.article.slug as string;
+}
+
+async function loginInBrowser(
+  page: Page,
+  email: string,
+  token: string,
+  username: string,
+) {
+  await page.goto(`${BASE}/`);
+  await page.evaluate(
+    ({ token, user }) => {
+      localStorage.setItem("conduit_token", token);
+      localStorage.setItem("conduit_user", JSON.stringify(user));
+    },
+    {
+      token,
+      user: { email, token, username, bio: null, image: null },
+    },
+  );
+}
+
+test.describe("Comment Section", () => {
+  test("should show sign in prompt when not authenticated", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(token, `Comment Test ${Date.now()}`);
+
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await expect(
+      page.getByText("to add comments on this article"),
+    ).toBeVisible({ timeout: 10000 });
+    // The sign-in prompt should contain links
+    await expect(
+      page.locator('[class*="signInPrompt"]'),
+    ).toBeVisible();
+  });
+
+  test("should show comment form when authenticated", async ({ page }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(token, `Comment Form ${Date.now()}`);
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    await expect(page.getByPlaceholder("Write a comment...")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Post Comment")).toBeVisible();
+  });
+
+  test("should post a comment and show it in the list", async ({ page }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(token, `Add Comment ${Date.now()}`);
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    const textarea = page.getByPlaceholder("Write a comment...");
+    await expect(textarea).toBeVisible({ timeout: 10000 });
+
+    await textarea.fill("This is my test comment!");
+    await page.getByText("Post Comment").click();
+
+    // Comment should appear in the list
+    await expect(page.getByText("This is my test comment!")).toBeVisible({
+      timeout: 10000,
+    });
+    // Author name should be visible in the comment card
+    await expect(
+      page.locator('[class*="commentAuthorName"]').first(),
+    ).toContainText(user.username);
+  });
+
+  test("should clear textarea after posting", async ({ page }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(token, `Clear Textarea ${Date.now()}`);
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    const textarea = page.getByPlaceholder("Write a comment...");
+    await expect(textarea).toBeVisible({ timeout: 10000 });
+
+    await textarea.fill("Comment to clear");
+    await page.getByText("Post Comment").click();
+
+    // Wait for the comment to appear
+    await expect(page.getByText("Comment to clear")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Textarea should be cleared
+    await expect(textarea).toHaveValue("");
+  });
+
+  test("should show delete button only for own comments", async ({ page }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    const slug = await createArticleApi(
+      authorToken,
+      `Delete Check ${Date.now()}`,
+    );
+
+    // Author posts a comment via API
+    await fetch(`${API}/articles/${slug}/comments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${authorToken}`,
+      },
+      body: JSON.stringify({ comment: { body: "Author comment" } }),
+    });
+
+    // Another user views the article
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    await expect(page.getByText("Author comment")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // No delete button since it's not own comment
+    await expect(page.locator('[class*="commentDeleteBtn"]')).toHaveCount(0);
+  });
+
+  test("should delete own comment", async ({ page }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(
+      token,
+      `Delete Comment ${Date.now()}`,
+    );
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    const textarea = page.getByPlaceholder("Write a comment...");
+    await expect(textarea).toBeVisible({ timeout: 10000 });
+
+    await textarea.fill("Comment to delete");
+    await page.getByText("Post Comment").click();
+
+    await expect(page.getByText("Comment to delete")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Click delete button
+    await page.locator('[class*="commentDeleteBtn"]').click();
+
+    // Comment should be removed
+    await expect(page.getByText("Comment to delete")).not.toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("should show multiple comments", async ({ page }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(
+      token,
+      `Multi Comment ${Date.now()}`,
+    );
+
+    // Create comments via API
+    for (const body of ["First comment", "Second comment", "Third comment"]) {
+      await fetch(`${API}/articles/${slug}/comments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Token ${token}`,
+        },
+        body: JSON.stringify({ comment: { body } }),
+      });
+    }
+
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await expect(page.getByText("First comment")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Second comment")).toBeVisible();
+    await expect(page.getByText("Third comment")).toBeVisible();
+
+    const commentCards = page.locator('[class*="commentCard"]');
+    const count = await commentCards.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  test("Post Comment button should be disabled when textarea is empty", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    const slug = await createArticleApi(
+      token,
+      `Disabled Btn ${Date.now()}`,
+    );
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    await expect(page.getByPlaceholder("Write a comment...")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const postBtn = page.getByText("Post Comment");
+    await expect(postBtn).toBeDisabled();
+  });
+});

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,0 +1,47 @@
+import apiClient from "./client";
+
+export interface Comment {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  body: string;
+  author: {
+    username: string;
+    bio: string;
+    image: string;
+    following: boolean;
+  };
+}
+
+interface CommentsResponse {
+  comments: Comment[];
+}
+
+interface CommentResponse {
+  comment: Comment;
+}
+
+export async function listCommentsApi(slug: string): Promise<Comment[]> {
+  const { data } = await apiClient.get<CommentsResponse>(
+    `/articles/${slug}/comments`,
+  );
+  return data.comments;
+}
+
+export async function addCommentApi(
+  slug: string,
+  body: string,
+): Promise<Comment> {
+  const { data } = await apiClient.post<CommentResponse>(
+    `/articles/${slug}/comments`,
+    { comment: { body } },
+  );
+  return data.comment;
+}
+
+export async function deleteCommentApi(
+  slug: string,
+  id: number,
+): Promise<void> {
+  await apiClient.delete(`/articles/${slug}/comments/${id}`);
+}

--- a/frontend/src/pages/article-page.module.css
+++ b/frontend/src/pages/article-page.module.css
@@ -98,3 +98,141 @@
   border-radius: 10rem;
   font-size: 0.8rem;
 }
+
+/* Comment Section */
+.commentSection {
+  max-width: 660px;
+  margin: 0 auto 2rem;
+}
+
+.commentForm {
+  border: 1px solid #e5e5e5;
+  border-radius: 0.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.commentTextarea {
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border: none;
+  border-bottom: 1px solid #e5e5e5;
+  resize: vertical;
+  min-height: 100px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.commentTextarea:focus {
+  outline: none;
+}
+
+.commentFormFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  background: #f5f5f5;
+}
+
+.commentFormImage {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.postCommentBtn {
+  background: #5cb85c;
+  color: #fff;
+  border: none;
+  padding: 0.4rem 1rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.postCommentBtn:hover {
+  background: #449d44;
+}
+
+.postCommentBtn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+/* Comment Card */
+.commentCard {
+  border: 1px solid #e5e5e5;
+  border-radius: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.commentBody {
+  padding: 1rem 1.25rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.commentCardFooter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: #f5f5f5;
+  border-top: 1px solid #e5e5e5;
+}
+
+.commentAuthorImage {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.commentAuthorName {
+  color: #5cb85c;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.commentAuthorName:hover {
+  text-decoration: underline;
+}
+
+.commentDate {
+  color: #bbb;
+  font-size: 0.8rem;
+  font-weight: 300;
+}
+
+.commentDeleteBtn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0;
+}
+
+.commentDeleteBtn:hover {
+  color: #b85c5c;
+}
+
+.signInPrompt {
+  text-align: center;
+  padding: 1rem;
+  color: #999;
+}
+
+.signInPrompt a {
+  color: #5cb85c;
+  text-decoration: none;
+}
+
+.signInPrompt a:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/pages/article-page.tsx
+++ b/frontend/src/pages/article-page.tsx
@@ -4,6 +4,12 @@ import { marked } from "marked";
 import { useAuth } from "@/hooks/use-auth";
 import { getArticleApi, deleteArticleApi } from "@/api/articles";
 import type { Article } from "@/api/articles";
+import {
+  listCommentsApi,
+  addCommentApi,
+  deleteCommentApi,
+  type Comment,
+} from "@/api/comments";
 import styles from "./article-page.module.css";
 
 function ArticlePage() {
@@ -126,6 +132,135 @@ function ArticlePage() {
           </div>
         </div>
         <hr />
+        <CommentSection slug={slug!} />
+      </div>
+    </div>
+  );
+}
+
+const DEFAULT_IMAGE = "https://api.realworld.io/images/smiley-cyrus.jpeg";
+
+function CommentSection({ slug }: { slug: string }) {
+  const { user, isAuthenticated } = useAuth();
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [commentBody, setCommentBody] = useState("");
+  const [posting, setPosting] = useState(false);
+
+  useEffect(() => {
+    listCommentsApi(slug).then(setComments).catch(() => {});
+  }, [slug]);
+
+  async function handlePostComment(e: React.FormEvent) {
+    e.preventDefault();
+    if (!commentBody.trim() || posting) return;
+    setPosting(true);
+    try {
+      const newComment = await addCommentApi(slug, commentBody);
+      setComments((prev) => [newComment, ...prev]);
+      setCommentBody("");
+    } catch {
+      // ignore
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  async function handleDeleteComment(id: number) {
+    try {
+      await deleteCommentApi(slug, id);
+      setComments((prev) => prev.filter((c) => c.id !== id));
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <div className={styles.commentSection}>
+      {isAuthenticated ? (
+        <form className={styles.commentForm} onSubmit={handlePostComment}>
+          <textarea
+            className={styles.commentTextarea}
+            placeholder="Write a comment..."
+            value={commentBody}
+            onChange={(e) => setCommentBody(e.target.value)}
+            rows={3}
+          />
+          <div className={styles.commentFormFooter}>
+            <img
+              className={styles.commentFormImage}
+              src={user?.image || DEFAULT_IMAGE}
+              alt={user?.username || ""}
+            />
+            <button
+              className={styles.postCommentBtn}
+              type="submit"
+              disabled={posting || !commentBody.trim()}
+            >
+              Post Comment
+            </button>
+          </div>
+        </form>
+      ) : (
+        <p className={styles.signInPrompt}>
+          <Link to="/login">Sign in</Link> or{" "}
+          <Link to="/register">sign up</Link> to add comments on this article.
+        </p>
+      )}
+
+      {comments.map((comment) => (
+        <CommentCard
+          key={comment.id}
+          comment={comment}
+          currentUsername={user?.username}
+          onDelete={handleDeleteComment}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CommentCard({
+  comment,
+  currentUsername,
+  onDelete,
+}: {
+  comment: Comment;
+  currentUsername?: string;
+  onDelete: (id: number) => void;
+}) {
+  const formattedDate = new Date(comment.createdAt).toLocaleDateString(
+    "en-US",
+    { year: "numeric", month: "long", day: "numeric" },
+  );
+  const isOwn = currentUsername === comment.author.username;
+
+  return (
+    <div className={styles.commentCard}>
+      <div className={styles.commentBody}>{comment.body}</div>
+      <div className={styles.commentCardFooter}>
+        <Link to={`/profile/${comment.author.username}`}>
+          <img
+            className={styles.commentAuthorImage}
+            src={comment.author.image || DEFAULT_IMAGE}
+            alt={comment.author.username}
+          />
+        </Link>
+        <Link
+          to={`/profile/${comment.author.username}`}
+          className={styles.commentAuthorName}
+        >
+          {comment.author.username}
+        </Link>
+        <span className={styles.commentDate}>{formattedDate}</span>
+        {isOwn && (
+          <button
+            className={styles.commentDeleteBtn}
+            onClick={() => onDelete(comment.id)}
+            title="Delete comment"
+          >
+            🗑
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- 기사 상세 페이지에 댓글 섹션 추가 (CommentSection + CommentCard 컴포넌트)
- 인증 사용자: 댓글 작성 폼 (textarea + Post Comment 버튼, 빈 입력 시 disabled)
- 미인증 사용자: Sign in / Sign up 안내 메시지
- 본인 댓글에만 삭제 버튼 표시 + 삭제 기능
- comments API 모듈 신규 (listCommentsApi, addCommentApi, deleteCommentApi)

## Test Plan
- **Unit**: N/A (컴포넌트 단위 테스트 별도)
- **Integration**: comments.ts API 모듈이 axios client를 통해 BE 엔드포인트와 정상 연동
- **E2E**: Playwright 8개 테스트 전체 PASS
  - 미인증 시 sign-in 안내 표시
  - 인증 시 댓글 폼 표시
  - 댓글 작성 + 목록 표시
  - 작성 후 textarea 초기화
  - 본인 댓글 삭제 버튼 표시/미표시
  - 본인 댓글 삭제
  - 다수 댓글 표시
  - 빈 입력 시 Post Comment 버튼 disabled
- **Visual**: 브라우저에서 댓글 폼/카드 레이아웃 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)