### PR TITLE
feat(frontend): 즐겨찾기 버튼 — Optimistic Update + 카운트 #22

### DIFF
--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
@@ -121,10 +121,19 @@ public class ArticleController {
   }
 
   @GetMapping("/articles/{slug}")
-  public ResponseEntity<Map<String, ArticleResponse>> getArticle(@PathVariable String slug) {
+  public ResponseEntity<Map<String, ArticleResponse>> getArticle(
+      Authentication authentication, @PathVariable String slug) {
     Article article = getArticleUseCase.getBySlug(slug);
     User author = findAuthor(article.getAuthorId());
-    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
+    Long currentUserId = getCurrentUserId(authentication);
+    boolean isFavorited =
+        currentUserId != null
+            && favoriteRepository.existsByUserIdAndArticleId(currentUserId, article.getId());
+    boolean isFollowing =
+        currentUserId != null
+            && followRepository.existsByFollowerIdAndFolloweeId(currentUserId, article.getAuthorId());
+    return ResponseEntity.ok(
+        Map.of("article", ArticleResponse.from(article, author, isFavorited, isFollowing)));
   }
 
   @PutMapping("/articles/{slug}")

--- a/frontend/e2e/favorite-button.spec.ts
+++ b/frontend/e2e/favorite-button.spec.ts
@@ -1,0 +1,265 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE = "http://localhost:5174";
+const API = "http://localhost:8080/api";
+
+let userCounter = 0;
+function uniqueUser() {
+  userCounter++;
+  const ts = Date.now();
+  return {
+    username: `favuser${userCounter}${ts}`,
+    email: `favuser${userCounter}${ts}@test.com`,
+    password: "password123",
+  };
+}
+
+async function registerApi(user: {
+  username: string;
+  email: string;
+  password: string;
+}) {
+  const res = await fetch(`${API}/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user }),
+  });
+  const data = await res.json();
+  return data.user.token as string;
+}
+
+async function createArticleApi(token: string, title: string) {
+  const res = await fetch(`${API}/articles`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Token ${token}`,
+    },
+    body: JSON.stringify({
+      article: {
+        title,
+        description: `Description for ${title}`,
+        body: `Body for ${title}`,
+        tagList: [],
+      },
+    }),
+  });
+  const data = await res.json();
+  return data.article.slug as string;
+}
+
+async function loginInBrowser(
+  page: Page,
+  email: string,
+  token: string,
+  username: string,
+) {
+  await page.goto(`${BASE}/`);
+  await page.evaluate(
+    ({ token, user }) => {
+      localStorage.setItem("conduit_token", token);
+      localStorage.setItem("conduit_user", JSON.stringify(user));
+    },
+    {
+      token,
+      user: { email, token, username, bio: null, image: null },
+    },
+  );
+}
+
+test.describe("Favorite Button", () => {
+  test("should show favorite button on article preview in home feed", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    await createArticleApi(token, `Fav Home ${Date.now()}`);
+
+    await page.goto(`${BASE}/`);
+    // Wait for articles to load
+    await expect(page.locator('[class*="favoriteBtn"]').first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("should show favorite button on article page for non-author", async ({
+    page,
+  }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    const slug = await createArticleApi(
+      authorToken,
+      `Fav Article ${Date.now()}`,
+    );
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    await expect(
+      page.getByText(/Favorite Article \(\d+\)/),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should not show favorite button for article author", async ({
+    page,
+  }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    const slug = await createArticleApi(
+      authorToken,
+      `Own Article ${Date.now()}`,
+    );
+
+    await loginInBrowser(page, author.email, authorToken, author.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    // Author should see edit/delete, not favorite
+    await expect(page.getByText("Edit Article")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByText(/Favorite Article/),
+    ).not.toBeVisible();
+  });
+
+  test("should toggle favorite on article preview (optimistic update)", async ({
+    page,
+  }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    await createArticleApi(authorToken, `Toggle Fav ${Date.now()}`);
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+
+    await page.goto(`${BASE}/`);
+    await page.reload();
+
+    // Authenticated user sees "Your Feed" by default — switch to "Global Feed"
+    await page.getByText("Global Feed").click();
+
+    // Find the first favorite button
+    const favBtn = page.locator('[class*="favoriteBtn"]').first();
+    await expect(favBtn).toBeVisible({ timeout: 10000 });
+
+    // Initial count should be 0
+    await expect(favBtn).toContainText("0");
+
+    // Click to favorite
+    await favBtn.click();
+
+    // Should show count 1 (optimistic)
+    await expect(favBtn).toContainText("1", { timeout: 5000 });
+
+    // Click to unfavorite
+    await favBtn.click();
+
+    // Should show count 0 again
+    await expect(favBtn).toContainText("0", { timeout: 5000 });
+  });
+
+  test("should toggle favorite on article page", async ({ page }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    const slug = await createArticleApi(
+      authorToken,
+      `Page Fav ${Date.now()}`,
+    );
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    const favBtn = page.getByText(/Favorite Article \(\d+\)/);
+    await expect(favBtn).toBeVisible({ timeout: 10000 });
+    await expect(favBtn).toContainText("(0)");
+
+    // Click to favorite
+    await favBtn.click();
+
+    // Should change to "Unfavorite Article (1)"
+    await expect(
+      page.getByText(/Unfavorite Article \(1\)/),
+    ).toBeVisible({ timeout: 5000 });
+
+    // Click to unfavorite
+    await page.getByText(/Unfavorite Article/).click();
+
+    // Should change back
+    await expect(
+      page.getByText(/Favorite Article \(0\)/),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should redirect to login when unauthenticated user clicks favorite", async ({
+    page,
+  }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    await createArticleApi(authorToken, `NoAuth Fav ${Date.now()}`);
+
+    await page.goto(`${BASE}/`);
+
+    const favBtn = page.locator('[class*="favoriteBtn"]').first();
+    await expect(favBtn).toBeVisible({ timeout: 10000 });
+
+    await favBtn.click();
+
+    // Should navigate to login page
+    await expect(page).toHaveURL(/\/#\/login/, { timeout: 5000 });
+  });
+
+  test("should show active style when article is favorited", async ({
+    page,
+  }) => {
+    const author = uniqueUser();
+    const authorToken = await registerApi(author);
+    const slug = await createArticleApi(
+      authorToken,
+      `Style Fav ${Date.now()}`,
+    );
+
+    const viewer = uniqueUser();
+    const viewerToken = await registerApi(viewer);
+
+    // Favorite via API first
+    await fetch(`${API}/articles/${slug}/favorite`, {
+      method: "POST",
+      headers: { Authorization: `Token ${viewerToken}` },
+    });
+
+    await loginInBrowser(page, viewer.email, viewerToken, viewer.username);
+    await page.goto(`${BASE}/#/article/${slug}`);
+    await page.reload();
+
+    // Should show "Unfavorite" (already favorited)
+    await expect(
+      page.getByText(/Unfavorite Article \(1\)/),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("should show favorite button on profile page article list", async ({
+    page,
+  }) => {
+    const user = uniqueUser();
+    const token = await registerApi(user);
+    await createArticleApi(token, `Profile Fav ${Date.now()}`);
+
+    await loginInBrowser(page, user.email, token, user.username);
+    await page.goto(`${BASE}/#/profile/${user.username}`);
+    await page.reload();
+
+    await expect(page.locator('[class*="favoriteBtn"]').first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/frontend/src/api/articles.ts
+++ b/frontend/src/api/articles.ts
@@ -95,3 +95,17 @@ export async function feedArticlesApi(
   );
   return data;
 }
+
+export async function favoriteArticleApi(slug: string): Promise<Article> {
+  const { data } = await apiClient.post<ArticleResponse>(
+    `/articles/${slug}/favorite`,
+  );
+  return data.article;
+}
+
+export async function unfavoriteArticleApi(slug: string): Promise<Article> {
+  const { data } = await apiClient.delete<ArticleResponse>(
+    `/articles/${slug}/favorite`,
+  );
+  return data.article;
+}

--- a/frontend/src/components/favorite-button.module.css
+++ b/frontend/src/components/favorite-button.module.css
@@ -1,0 +1,48 @@
+.favoriteBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid #5cb85c;
+  color: #5cb85c;
+  background: transparent;
+  border-radius: 3px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
+  white-space: nowrap;
+}
+
+.favoriteBtn:hover {
+  color: #fff;
+  background-color: #5cb85c;
+}
+
+.favoriteBtnActive {
+  composes: favoriteBtn;
+  color: #fff;
+  background-color: #5cb85c;
+}
+
+.favoriteBtnActive:hover {
+  background-color: #449d44;
+  border-color: #449d44;
+}
+
+/* Larger variant for article page banner */
+.favoriteBtnLg {
+  composes: favoriteBtn;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+.favoriteBtnLgActive {
+  composes: favoriteBtnLg;
+  color: #fff;
+  background-color: #5cb85c;
+}
+
+.favoriteBtnLgActive:hover {
+  background-color: #449d44;
+  border-color: #449d44;
+}

--- a/frontend/src/components/favorite-button.tsx
+++ b/frontend/src/components/favorite-button.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  favoriteArticleApi,
+  unfavoriteArticleApi,
+} from "@/api/articles";
+import styles from "./favorite-button.module.css";
+
+interface FavoriteButtonProps {
+  slug: string;
+  favorited: boolean;
+  favoritesCount: number;
+  size?: "sm" | "lg";
+  onToggled?: (favorited: boolean, count: number) => void;
+}
+
+export default function FavoriteButton({
+  slug,
+  favorited: initialFavorited,
+  favoritesCount: initialCount,
+  size = "sm",
+  onToggled,
+}: FavoriteButtonProps) {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const [favorited, setFavorited] = useState(initialFavorited);
+  const [count, setCount] = useState(initialCount);
+  const [loading, setLoading] = useState(false);
+
+  async function handleClick() {
+    if (!isAuthenticated) {
+      navigate("/login");
+      return;
+    }
+    if (loading) return;
+
+    // Optimistic update
+    const prevFavorited = favorited;
+    const prevCount = count;
+    const newFavorited = !favorited;
+    const newCount = newFavorited ? count + 1 : count - 1;
+
+    setFavorited(newFavorited);
+    setCount(newCount);
+    setLoading(true);
+
+    try {
+      const article = newFavorited
+        ? await favoriteArticleApi(slug)
+        : await unfavoriteArticleApi(slug);
+      setFavorited(article.favorited);
+      setCount(article.favoritesCount);
+      onToggled?.(article.favorited, article.favoritesCount);
+    } catch {
+      // Rollback
+      setFavorited(prevFavorited);
+      setCount(prevCount);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  let className: string;
+  if (size === "lg") {
+    className = favorited ? styles.favoriteBtnLgActive : styles.favoriteBtnLg;
+  } else {
+    className = favorited ? styles.favoriteBtnActive : styles.favoriteBtn;
+  }
+
+  return (
+    <button className={className} onClick={handleClick} disabled={loading}>
+      {favorited ? "♥" : "♡"}{" "}
+      {size === "lg"
+        ? `${favorited ? "Unfavorite" : "Favorite"} Article (${count})`
+        : count}
+    </button>
+  );
+}

--- a/frontend/src/pages/article-page.tsx
+++ b/frontend/src/pages/article-page.tsx
@@ -4,6 +4,7 @@ import { marked } from "marked";
 import { useAuth } from "@/hooks/use-auth";
 import { getArticleApi, deleteArticleApi } from "@/api/articles";
 import type { Article } from "@/api/articles";
+import FavoriteButton from "@/components/favorite-button";
 import {
   listCommentsApi,
   addCommentApi,
@@ -96,7 +97,7 @@ function ArticlePage() {
               </Link>
               <span className={styles.date}>{formattedDate}</span>
             </div>
-            {isAuthor && (
+            {isAuthor ? (
               <div className={styles.actions}>
                 <Link
                   to={`/editor/${article.slug}`}
@@ -111,6 +112,20 @@ function ArticlePage() {
                 >
                   <i className="ion-trash-a" /> Delete Article
                 </button>
+              </div>
+            ) : (
+              <div className={styles.actions}>
+                <FavoriteButton
+                  slug={article.slug}
+                  favorited={article.favorited}
+                  favoritesCount={article.favoritesCount}
+                  size="lg"
+                  onToggled={(fav, cnt) =>
+                    setArticle((prev) =>
+                      prev ? { ...prev, favorited: fav, favoritesCount: cnt } : prev,
+                    )
+                  }
+                />
               </div>
             )}
           </div>

--- a/frontend/src/pages/home-page.tsx
+++ b/frontend/src/pages/home-page.tsx
@@ -7,6 +7,7 @@ import {
   type Article,
 } from "@/api/articles";
 import { getTagsApi } from "@/api/tags";
+import FavoriteButton from "@/components/favorite-button";
 import styles from "./home-page.module.css";
 
 const ARTICLES_PER_PAGE = 10;
@@ -209,9 +210,11 @@ function ArticlePreview({ article }: { article: Article }) {
           </Link>
           <span className={styles.articleDate}>{formattedDate}</span>
         </div>
-        <span className={styles.favCount}>
-          ♥ {article.favoritesCount}
-        </span>
+        <FavoriteButton
+          slug={article.slug}
+          favorited={article.favorited}
+          favoritesCount={article.favoritesCount}
+        />
       </div>
       <Link to={`/article/${article.slug}`} className={styles.previewLink}>
         <h2 className={styles.previewTitle}>{article.title}</h2>

--- a/frontend/src/pages/profile-page.tsx
+++ b/frontend/src/pages/profile-page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { getProfileApi, followUserApi, unfollowUserApi } from "@/api/profiles";
 import type { Profile } from "@/api/profiles";
 import { listArticlesApi, type Article } from "@/api/articles";
+import FavoriteButton from "@/components/favorite-button";
 import styles from "./profile-page.module.css";
 
 const ARTICLES_PER_PAGE = 10;
@@ -234,7 +235,11 @@ function ArticlePreview({ article }: { article: Article }) {
           </Link>
           <span className={styles.articleDate}>{formattedDate}</span>
         </div>
-        <span className={styles.favCount}>♥ {article.favoritesCount}</span>
+        <FavoriteButton
+          slug={article.slug}
+          favorited={article.favorited}
+          favoritesCount={article.favoritesCount}
+        />
       </div>
       <Link to={`/article/${article.slug}`} className={styles.previewLink}>
         <h2 className={styles.previewTitle}>{article.title}</h2>


### PR DESCRIPTION
## Summary
- `FavoriteButton` 컴포넌트 신규: 하트 아이콘 + favoritesCount, optimistic update + API 실패 시 롤백
- `ArticlePreview` (홈 피드 + 프로필 페이지)에 FavoriteButton 통합 (기존 정적 ♥ 카운트 대체)
- `ArticlePage` 배너에 FavoriteButton(lg 사이즈) 통합 — 비저자일 때만 표시
- 비인증 사용자 클릭 시 `/login`으로 리다이렉트
- BE 수정: `GET /articles/:slug`에 optional auth 추가 → `favorited`/`following` 정확히 반환

## Test Plan
- **Unit**: N/A
- **Integration**: favorite/unfavorite API (POST/DELETE /articles/:slug/favorite) 연동 확인
- **E2E**: Playwright 8개 테스트 전체 PASS
  - 홈 피드에 즐겨찾기 버튼 표시
  - 기사 페이지 비저자에게 즐겨찾기 버튼 표시
  - 기사 저자에게 즐겨찾기 버튼 미표시
  - 홈 피드에서 토글 (optimistic update)
  - 기사 페이지에서 토글
  - 비인증 사용자 클릭 → 로그인 리다이렉트
  - API로 사전 즐겨찾기 시 활성 스타일 표시
  - 프로필 페이지에서 즐겨찾기 버튼 표시
- **Visual**: 브라우저에서 하트 버튼 토글 확인

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)