### PR TITLE
docs(backend): Springdoc OpenAPI 문서화 — Swagger UI

### DIFF
--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleController.java
@@ -14,6 +14,11 @@ import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import com.conduit.user.domain.model.User;
 import com.conduit.user.domain.port.out.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +38,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Articles", description = "Article CRUD and favorites")
 @RestController
 @RequestMapping("/api")
 public class ArticleController {
@@ -74,10 +80,16 @@ public class ArticleController {
     this.followRepository = followRepository;
   }
 
+  @Operation(
+      summary = "Create an article",
+      description = "Create a new article. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Article created")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "422", description = "Validation error")
   @PostMapping("/articles")
   public ResponseEntity<Map<String, ArticleResponse>> createArticle(
-      Authentication authentication,
-      @Valid @RequestBody Map<String, CreateArticleRequest> body) {
+      Authentication authentication, @Valid @RequestBody Map<String, CreateArticleRequest> body) {
     Long userId = (Long) authentication.getPrincipal();
     CreateArticleRequest req = body.get("article");
     Article article =
@@ -87,14 +99,25 @@ public class ArticleController {
     return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
   }
 
+  @Operation(
+      summary = "List articles",
+      description =
+          "List articles filtered by tag, author, or favorited user. Supports pagination.")
+  @ApiResponse(responseCode = "200", description = "Articles list with count")
   @GetMapping("/articles")
   public ResponseEntity<Map<String, Object>> listArticles(
       Authentication authentication,
-      @RequestParam(required = false) String tag,
-      @RequestParam(required = false) String author,
-      @RequestParam(required = false) String favorited,
-      @RequestParam(defaultValue = "20") int limit,
-      @RequestParam(defaultValue = "0") int offset) {
+      @Parameter(description = "Filter by tag") @RequestParam(required = false) String tag,
+      @Parameter(description = "Filter by author username") @RequestParam(required = false)
+          String author,
+      @Parameter(description = "Filter by user who favorited") @RequestParam(required = false)
+          String favorited,
+      @Parameter(description = "Limit number of articles (default 20)")
+          @RequestParam(defaultValue = "20")
+          int limit,
+      @Parameter(description = "Offset/skip number of articles (default 0)")
+          @RequestParam(defaultValue = "0")
+          int offset) {
     List<Article> articles =
         listArticlesUseCase.listArticles(tag, author, favorited, limit, offset);
     long articlesCount = listArticlesUseCase.countArticles(tag, author, favorited);
@@ -105,11 +128,17 @@ public class ArticleController {
     return ResponseEntity.ok(Map.of("articles", responses, "articlesCount", articlesCount));
   }
 
+  @Operation(
+      summary = "Feed articles",
+      description = "Get articles from users you follow. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Feed articles with count")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
   @GetMapping("/articles/feed")
   public ResponseEntity<Map<String, Object>> feedArticles(
       Authentication authentication,
-      @RequestParam(defaultValue = "20") int limit,
-      @RequestParam(defaultValue = "0") int offset) {
+      @Parameter(description = "Limit (default 20)") @RequestParam(defaultValue = "20") int limit,
+      @Parameter(description = "Offset (default 0)") @RequestParam(defaultValue = "0") int offset) {
     Long userId = (Long) authentication.getPrincipal();
 
     List<Article> articles = feedArticlesUseCase.feedArticles(userId, limit, offset);
@@ -120,9 +149,15 @@ public class ArticleController {
     return ResponseEntity.ok(Map.of("articles", responses, "articlesCount", articlesCount));
   }
 
+  @Operation(
+      summary = "Get an article",
+      description = "Get a single article by slug. No auth required.")
+  @ApiResponse(responseCode = "200", description = "Article found")
+  @ApiResponse(responseCode = "404", description = "Article not found")
   @GetMapping("/articles/{slug}")
   public ResponseEntity<Map<String, ArticleResponse>> getArticle(
-      Authentication authentication, @PathVariable String slug) {
+      Authentication authentication,
+      @Parameter(description = "Slug of the article") @PathVariable String slug) {
     Article article = getArticleUseCase.getBySlug(slug);
     User author = findAuthor(article.getAuthorId());
     Long currentUserId = getCurrentUserId(authentication);
@@ -131,15 +166,24 @@ public class ArticleController {
             && favoriteRepository.existsByUserIdAndArticleId(currentUserId, article.getId());
     boolean isFollowing =
         currentUserId != null
-            && followRepository.existsByFollowerIdAndFolloweeId(currentUserId, article.getAuthorId());
+            && followRepository.existsByFollowerIdAndFolloweeId(
+                currentUserId, article.getAuthorId());
     return ResponseEntity.ok(
         Map.of("article", ArticleResponse.from(article, author, isFavorited, isFollowing)));
   }
 
+  @Operation(
+      summary = "Update an article",
+      description = "Update an article. Auth required. Only the author can update.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Article updated")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden — not the author")
+  @ApiResponse(responseCode = "404", description = "Article not found")
   @PutMapping("/articles/{slug}")
   public ResponseEntity<Map<String, ArticleResponse>> updateArticle(
       Authentication authentication,
-      @PathVariable String slug,
+      @Parameter(description = "Slug of the article") @PathVariable String slug,
       @RequestBody Map<String, UpdateArticleRequest> body) {
     Long userId = (Long) authentication.getPrincipal();
     UpdateArticleRequest req = body.get("article");
@@ -149,32 +193,61 @@ public class ArticleController {
     return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author)));
   }
 
+  @Operation(
+      summary = "Delete an article",
+      description = "Delete an article. Auth required. Only the author can delete.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "204", description = "Article deleted")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden — not the author")
+  @ApiResponse(responseCode = "404", description = "Article not found")
   @DeleteMapping("/articles/{slug}")
   public ResponseEntity<Void> deleteArticle(
-      Authentication authentication, @PathVariable String slug) {
+      Authentication authentication,
+      @Parameter(description = "Slug of the article") @PathVariable String slug) {
     Long userId = (Long) authentication.getPrincipal();
     deleteArticleUseCase.delete(slug, userId);
     return ResponseEntity.noContent().build();
   }
 
+  @Operation(
+      summary = "Favorite an article",
+      description = "Favorite an article. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Article favorited")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "404", description = "Article not found")
   @PostMapping("/articles/{slug}/favorite")
   public ResponseEntity<Map<String, ArticleResponse>> favoriteArticle(
-      Authentication authentication, @PathVariable String slug) {
+      Authentication authentication,
+      @Parameter(description = "Slug of the article") @PathVariable String slug) {
     Long userId = (Long) authentication.getPrincipal();
     Article article = favoriteArticleUseCase.favorite(slug, userId);
     User author = findAuthor(article.getAuthorId());
-    boolean isFollowing = followRepository.existsByFollowerIdAndFolloweeId(userId, article.getAuthorId());
-    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author, true, isFollowing)));
+    boolean isFollowing =
+        followRepository.existsByFollowerIdAndFolloweeId(userId, article.getAuthorId());
+    return ResponseEntity.ok(
+        Map.of("article", ArticleResponse.from(article, author, true, isFollowing)));
   }
 
+  @Operation(
+      summary = "Unfavorite an article",
+      description = "Unfavorite an article. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Article unfavorited")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "404", description = "Article not found")
   @DeleteMapping("/articles/{slug}/favorite")
   public ResponseEntity<Map<String, ArticleResponse>> unfavoriteArticle(
-      Authentication authentication, @PathVariable String slug) {
+      Authentication authentication,
+      @Parameter(description = "Slug of the article") @PathVariable String slug) {
     Long userId = (Long) authentication.getPrincipal();
     Article article = unfavoriteArticleUseCase.unfavorite(slug, userId);
     User author = findAuthor(article.getAuthorId());
-    boolean isFollowing = followRepository.existsByFollowerIdAndFolloweeId(userId, article.getAuthorId());
-    return ResponseEntity.ok(Map.of("article", ArticleResponse.from(article, author, false, isFollowing)));
+    boolean isFollowing =
+        followRepository.existsByFollowerIdAndFolloweeId(userId, article.getAuthorId());
+    return ResponseEntity.ok(
+        Map.of("article", ArticleResponse.from(article, author, false, isFollowing)));
   }
 
   private List<ArticleResponse> buildArticleResponses(List<Article> articles, Long currentUserId) {

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleResponse.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/ArticleResponse.java
@@ -2,20 +2,25 @@ package com.conduit.article.adapter.in.web;
 
 import com.conduit.article.domain.model.Article;
 import com.conduit.user.domain.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
 
+@Schema(description = "Article data")
 public record ArticleResponse(
-    String slug,
-    String title,
-    String description,
-    String body,
-    List<String> tagList,
-    Instant createdAt,
-    Instant updatedAt,
-    boolean favorited,
-    int favoritesCount,
-    AuthorResponse author) {
+    @Schema(description = "URL-friendly identifier", example = "how-to-train-your-dragon")
+        String slug,
+    @Schema(description = "Article title", example = "How to train your dragon") String title,
+    @Schema(description = "Short summary", example = "Ever wonder how?") String description,
+    @Schema(description = "Article body in Markdown", example = "## Introduction\n\nContent here")
+        String body,
+    @Schema(description = "List of tags", example = "[\"dragons\", \"training\"]")
+        List<String> tagList,
+    @Schema(description = "Creation timestamp") Instant createdAt,
+    @Schema(description = "Last update timestamp") Instant updatedAt,
+    @Schema(description = "Whether the current user has favorited this article") boolean favorited,
+    @Schema(description = "Total favorites count", example = "5") int favoritesCount,
+    @Schema(description = "Author profile") AuthorResponse author) {
 
   public static ArticleResponse from(Article article, User author) {
     return from(article, author, false, false);
@@ -36,5 +41,13 @@ public record ArticleResponse(
         new AuthorResponse(author.getUsername(), author.getBio(), author.getImage(), following));
   }
 
-  public record AuthorResponse(String username, String bio, String image, boolean following) {}
+  @Schema(description = "Author profile embedded in article")
+  public record AuthorResponse(
+      @Schema(description = "Username", example = "jake") String username,
+      @Schema(description = "Short bio", example = "I work at statefarm") String bio,
+      @Schema(
+              description = "Avatar URL",
+              example = "https://api.realworld.io/images/smiley-cyrus.jpeg")
+          String image,
+      @Schema(description = "Whether the current user follows this author") boolean following) {}
 }

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/CreateArticleRequest.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/CreateArticleRequest.java
@@ -1,10 +1,21 @@
 package com.conduit.article.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
+@Schema(description = "Article creation payload")
 public record CreateArticleRequest(
-    @NotBlank(message = "can't be blank") String title,
-    @NotBlank(message = "can't be blank") String description,
-    @NotBlank(message = "can't be blank") String body,
-    List<String> tagList) {}
+    @NotBlank(message = "can't be blank")
+        @Schema(description = "Article title", example = "How to train your dragon")
+        String title,
+    @NotBlank(message = "can't be blank")
+        @Schema(description = "Short summary of the article", example = "Ever wonder how?")
+        String description,
+    @NotBlank(message = "can't be blank")
+        @Schema(
+            description = "Article body in Markdown",
+            example = "## Introduction\n\nIt takes a Toothless...")
+        String body,
+    @Schema(description = "List of tags", example = "[\"dragons\", \"training\"]")
+        List<String> tagList) {}

--- a/backend/src/main/java/com/conduit/article/adapter/in/web/UpdateArticleRequest.java
+++ b/backend/src/main/java/com/conduit/article/adapter/in/web/UpdateArticleRequest.java
@@ -1,3 +1,9 @@
 package com.conduit.article.adapter.in.web;
 
-public record UpdateArticleRequest(String title, String description, String body) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Article update payload (all fields optional)")
+public record UpdateArticleRequest(
+    @Schema(description = "New title", example = "Updated title") String title,
+    @Schema(description = "New description", example = "Updated summary") String description,
+    @Schema(description = "New body in Markdown", example = "Updated body content") String body) {}

--- a/backend/src/main/java/com/conduit/comment/adapter/in/web/CommentController.java
+++ b/backend/src/main/java/com/conduit/comment/adapter/in/web/CommentController.java
@@ -6,10 +6,16 @@ import com.conduit.comment.domain.port.in.DeleteCommentUseCase;
 import com.conduit.comment.domain.port.in.ListCommentsUseCase;
 import com.conduit.user.domain.model.User;
 import com.conduit.user.domain.port.out.UserRepository;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,90 +26,102 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
+@Tag(name = "Comments", description = "Comments on articles")
 @RestController
 @RequestMapping("/api/articles/{slug}/comments")
 public class CommentController {
 
-    private final AddCommentUseCase addCommentUseCase;
-    private final ListCommentsUseCase listCommentsUseCase;
-    private final DeleteCommentUseCase deleteCommentUseCase;
-    private final UserRepository userRepository;
+  private final AddCommentUseCase addCommentUseCase;
+  private final ListCommentsUseCase listCommentsUseCase;
+  private final DeleteCommentUseCase deleteCommentUseCase;
+  private final UserRepository userRepository;
 
-    public CommentController(AddCommentUseCase addCommentUseCase,
-                              ListCommentsUseCase listCommentsUseCase,
-                              DeleteCommentUseCase deleteCommentUseCase,
-                              UserRepository userRepository) {
-        this.addCommentUseCase = addCommentUseCase;
-        this.listCommentsUseCase = listCommentsUseCase;
-        this.deleteCommentUseCase = deleteCommentUseCase;
-        this.userRepository = userRepository;
+  public CommentController(
+      AddCommentUseCase addCommentUseCase,
+      ListCommentsUseCase listCommentsUseCase,
+      DeleteCommentUseCase deleteCommentUseCase,
+      UserRepository userRepository) {
+    this.addCommentUseCase = addCommentUseCase;
+    this.listCommentsUseCase = listCommentsUseCase;
+    this.deleteCommentUseCase = deleteCommentUseCase;
+    this.userRepository = userRepository;
+  }
+
+  public record AddCommentRequest(@Valid CommentBody comment) {
+    public record CommentBody(@NotBlank String body) {}
+  }
+
+  @Operation(
+      summary = "Add comment to an article",
+      description = "Add a comment to an article. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Comment created")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "404", description = "Article not found")
+  @PostMapping
+  public ResponseEntity<Map<String, Object>> addComment(
+      @Parameter(description = "Slug of the article") @PathVariable String slug,
+      @RequestBody @Valid AddCommentRequest request,
+      Authentication authentication) {
+    Long userId = getCurrentUserId(authentication);
+    Comment comment = addCommentUseCase.addComment(slug, request.comment().body(), userId);
+    return ResponseEntity.ok(Map.of("comment", toResponse(comment)));
+  }
+
+  @Operation(
+      summary = "List comments for an article",
+      description = "Get all comments for an article. No auth required.")
+  @ApiResponse(responseCode = "200", description = "List of comments")
+  @GetMapping
+  public ResponseEntity<Map<String, Object>> listComments(
+      @Parameter(description = "Slug of the article") @PathVariable String slug) {
+    List<Comment> comments = listCommentsUseCase.listComments(slug);
+    List<Map<String, Object>> responses = comments.stream().map(this::toResponse).toList();
+    return ResponseEntity.ok(Map.of("comments", responses));
+  }
+
+  @Operation(
+      summary = "Delete a comment",
+      description = "Delete a comment. Auth required. Only the comment author can delete.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Comment deleted")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden — not the comment author")
+  @ApiResponse(responseCode = "404", description = "Comment not found")
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteComment(
+      @Parameter(description = "Slug of the article") @PathVariable String slug,
+      @Parameter(description = "Comment ID") @PathVariable Long id,
+      Authentication authentication) {
+    Long userId = getCurrentUserId(authentication);
+    deleteCommentUseCase.deleteComment(slug, id, userId);
+    return ResponseEntity.ok().build();
+  }
+
+  private Map<String, Object> toResponse(Comment comment) {
+    User author = userRepository.findById(comment.authorId()).orElse(null);
+
+    Map<String, Object> authorMap = new LinkedHashMap<>();
+    if (author != null) {
+      authorMap.put("username", author.getUsername());
+      authorMap.put("bio", author.getBio() != null ? author.getBio() : "");
+      authorMap.put("image", author.getImage() != null ? author.getImage() : "");
+      authorMap.put("following", false);
     }
 
-    public record AddCommentRequest(
-            @Valid CommentBody comment
-    ) {
-        public record CommentBody(
-                @NotBlank String body
-        ) {}
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("id", comment.id());
+    response.put("createdAt", comment.createdAt().toString());
+    response.put("updatedAt", comment.updatedAt().toString());
+    response.put("body", comment.body());
+    response.put("author", authorMap);
+    return response;
+  }
+
+  private Long getCurrentUserId(Authentication authentication) {
+    if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
+      return userId;
     }
-
-    @PostMapping
-    public ResponseEntity<Map<String, Object>> addComment(
-            @PathVariable String slug,
-            @RequestBody @Valid AddCommentRequest request,
-            Authentication authentication) {
-        Long userId = getCurrentUserId(authentication);
-        Comment comment = addCommentUseCase.addComment(slug, request.comment().body(), userId);
-        return ResponseEntity.ok(Map.of("comment", toResponse(comment)));
-    }
-
-    @GetMapping
-    public ResponseEntity<Map<String, Object>> listComments(@PathVariable String slug) {
-        List<Comment> comments = listCommentsUseCase.listComments(slug);
-        List<Map<String, Object>> responses = comments.stream()
-                .map(this::toResponse)
-                .toList();
-        return ResponseEntity.ok(Map.of("comments", responses));
-    }
-
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteComment(
-            @PathVariable String slug,
-            @PathVariable Long id,
-            Authentication authentication) {
-        Long userId = getCurrentUserId(authentication);
-        deleteCommentUseCase.deleteComment(slug, id, userId);
-        return ResponseEntity.ok().build();
-    }
-
-    private Map<String, Object> toResponse(Comment comment) {
-        User author = userRepository.findById(comment.authorId()).orElse(null);
-
-        Map<String, Object> authorMap = new LinkedHashMap<>();
-        if (author != null) {
-            authorMap.put("username", author.getUsername());
-            authorMap.put("bio", author.getBio() != null ? author.getBio() : "");
-            authorMap.put("image", author.getImage() != null ? author.getImage() : "");
-            authorMap.put("following", false);
-        }
-
-        Map<String, Object> response = new LinkedHashMap<>();
-        response.put("id", comment.id());
-        response.put("createdAt", comment.createdAt().toString());
-        response.put("updatedAt", comment.updatedAt().toString());
-        response.put("body", comment.body());
-        response.put("author", authorMap);
-        return response;
-    }
-
-    private Long getCurrentUserId(Authentication authentication) {
-        if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
-            return userId;
-        }
-        return null;
-    }
+    return null;
+  }
 }

--- a/backend/src/main/java/com/conduit/profile/adapter/in/web/ProfileController.java
+++ b/backend/src/main/java/com/conduit/profile/adapter/in/web/ProfileController.java
@@ -4,7 +4,12 @@ import com.conduit.profile.domain.model.Profile;
 import com.conduit.profile.domain.port.in.FollowUserUseCase;
 import com.conduit.profile.domain.port.in.GetProfileUseCase;
 import com.conduit.profile.domain.port.in.UnfollowUserUseCase;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,64 +19,86 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
+@Tag(name = "Profile", description = "User profiles and follow/unfollow")
 @RestController
 @RequestMapping("/api/profiles")
 public class ProfileController {
 
-    private final GetProfileUseCase getProfileUseCase;
-    private final FollowUserUseCase followUserUseCase;
-    private final UnfollowUserUseCase unfollowUserUseCase;
+  private final GetProfileUseCase getProfileUseCase;
+  private final FollowUserUseCase followUserUseCase;
+  private final UnfollowUserUseCase unfollowUserUseCase;
 
-    public ProfileController(GetProfileUseCase getProfileUseCase,
-                              FollowUserUseCase followUserUseCase,
-                              UnfollowUserUseCase unfollowUserUseCase) {
-        this.getProfileUseCase = getProfileUseCase;
-        this.followUserUseCase = followUserUseCase;
-        this.unfollowUserUseCase = unfollowUserUseCase;
-    }
+  public ProfileController(
+      GetProfileUseCase getProfileUseCase,
+      FollowUserUseCase followUserUseCase,
+      UnfollowUserUseCase unfollowUserUseCase) {
+    this.getProfileUseCase = getProfileUseCase;
+    this.followUserUseCase = followUserUseCase;
+    this.unfollowUserUseCase = unfollowUserUseCase;
+  }
 
-    @GetMapping("/{username}")
-    public ResponseEntity<Map<String, Object>> getProfile(
-            @PathVariable String username,
-            Authentication authentication) {
-        Long currentUserId = getCurrentUserId(authentication);
-        Profile profile = getProfileUseCase.getProfile(username, currentUserId);
-        return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
-    }
+  @Operation(
+      summary = "Get a profile",
+      description = "Get a user profile by username. No auth required.")
+  @ApiResponse(responseCode = "200", description = "Profile data")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @GetMapping("/{username}")
+  public ResponseEntity<Map<String, Object>> getProfile(
+      @Parameter(description = "Username of the profile") @PathVariable String username,
+      Authentication authentication) {
+    Long currentUserId = getCurrentUserId(authentication);
+    Profile profile = getProfileUseCase.getProfile(username, currentUserId);
+    return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
+  }
 
-    @PostMapping("/{username}/follow")
-    public ResponseEntity<Map<String, Object>> follow(
-            @PathVariable String username,
-            Authentication authentication) {
-        Long currentUserId = getCurrentUserId(authentication);
-        Profile profile = followUserUseCase.follow(username, currentUserId);
-        return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
-    }
+  @Operation(
+      summary = "Follow a user",
+      description = "Follow a user by username. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "User followed")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @PostMapping("/{username}/follow")
+  public ResponseEntity<Map<String, Object>> follow(
+      @Parameter(description = "Username to follow") @PathVariable String username,
+      Authentication authentication) {
+    Long currentUserId = getCurrentUserId(authentication);
+    Profile profile = followUserUseCase.follow(username, currentUserId);
+    return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
+  }
 
-    @DeleteMapping("/{username}/follow")
-    public ResponseEntity<Map<String, Object>> unfollow(
-            @PathVariable String username,
-            Authentication authentication) {
-        Long currentUserId = getCurrentUserId(authentication);
-        Profile profile = unfollowUserUseCase.unfollow(username, currentUserId);
-        return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
-    }
+  @Operation(
+      summary = "Unfollow a user",
+      description = "Unfollow a user by username. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "User unfollowed")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @DeleteMapping("/{username}/follow")
+  public ResponseEntity<Map<String, Object>> unfollow(
+      @Parameter(description = "Username to unfollow") @PathVariable String username,
+      Authentication authentication) {
+    Long currentUserId = getCurrentUserId(authentication);
+    Profile profile = unfollowUserUseCase.unfollow(username, currentUserId);
+    return ResponseEntity.ok(Map.of("profile", toResponse(profile)));
+  }
 
-    private Long getCurrentUserId(Authentication authentication) {
-        if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
-            return userId;
-        }
-        return null;
+  private Long getCurrentUserId(Authentication authentication) {
+    if (authentication != null && authentication.getPrincipal() instanceof Long userId) {
+      return userId;
     }
+    return null;
+  }
 
-    private Map<String, Object> toResponse(Profile profile) {
-        return Map.of(
-                "username", profile.username(),
-                "bio", profile.bio() != null ? profile.bio() : "",
-                "image", profile.image() != null ? profile.image() : "",
-                "following", profile.following()
-        );
-    }
+  private Map<String, Object> toResponse(Profile profile) {
+    return Map.of(
+        "username",
+        profile.username(),
+        "bio",
+        profile.bio() != null ? profile.bio() : "",
+        "image",
+        profile.image() != null ? profile.image() : "",
+        "following",
+        profile.following());
+  }
 }

--- a/backend/src/main/java/com/conduit/shared/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/conduit/shared/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.conduit.shared.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI conduitOpenAPI() {
+    return new OpenAPI()
+        .info(
+            new Info()
+                .title("Conduit API")
+                .description("RealWorld Conduit API — Medium.com clone")
+                .version("1.0.0"))
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "Token",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                        .name("Authorization")
+                        .description(
+                            "JWT token with 'Token ' prefix. Example: `Token eyJhbGci...`")));
+  }
+}

--- a/backend/src/main/java/com/conduit/shared/exception/ErrorResponse.java
+++ b/backend/src/main/java/com/conduit/shared/exception/ErrorResponse.java
@@ -1,9 +1,15 @@
 package com.conduit.shared.exception;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 
-public record ErrorResponse(Map<String, List<String>> errors) {
+@Schema(description = "Error response wrapper")
+public record ErrorResponse(
+    @Schema(
+            description = "Map of field names to error messages",
+            example = "{\"body\": [\"can't be blank\"]}")
+        Map<String, List<String>> errors) {
 
   public static ErrorResponse of(String field, String message) {
     return new ErrorResponse(Map.of(field, List.of(message)));

--- a/backend/src/main/java/com/conduit/tag/adapter/in/web/TagController.java
+++ b/backend/src/main/java/com/conduit/tag/adapter/in/web/TagController.java
@@ -1,6 +1,9 @@
 package com.conduit.tag.adapter.in.web;
 
 import com.conduit.tag.domain.port.in.GetTagsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Tags", description = "Tags for articles")
 @RestController
 @RequestMapping("/api")
 public class TagController {
@@ -18,6 +22,8 @@ public class TagController {
     this.getTagsUseCase = getTagsUseCase;
   }
 
+  @Operation(summary = "Get tags", description = "Get all tags used across articles")
+  @ApiResponse(responseCode = "200", description = "List of tags")
   @GetMapping("/tags")
   public ResponseEntity<Map<String, List<String>>> getTags() {
     List<String> tags = getTagsUseCase.getAllTagNames();

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/LoginRequest.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/LoginRequest.java
@@ -1,8 +1,12 @@
 package com.conduit.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "User login payload")
 public record LoginRequest(
-    @NotBlank(message = "can't be blank") String email,
-    @NotBlank(message = "can't be blank") String password
-) {}
+    @NotBlank(message = "can't be blank")
+        @Schema(description = "Email address", example = "jake@jake.jake")
+        String email,
+    @NotBlank(message = "can't be blank") @Schema(description = "Password", example = "jakejake")
+        String password) {}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/RegisterRequest.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/RegisterRequest.java
@@ -1,11 +1,19 @@
 package com.conduit.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "User registration payload")
 public record RegisterRequest(
-    @NotBlank(message = "can't be blank") String username,
-    @NotBlank(message = "can't be blank") @Email(message = "is invalid") String email,
-    @NotBlank(message = "can't be blank") @Size(min = 8, message = "is too short") String password
-) {}
+    @NotBlank(message = "can't be blank") @Schema(description = "Unique username", example = "jake")
+        String username,
+    @NotBlank(message = "can't be blank")
+        @Email(message = "is invalid")
+        @Schema(description = "Email address", example = "jake@jake.jake")
+        String email,
+    @NotBlank(message = "can't be blank")
+        @Size(min = 8, message = "is too short")
+        @Schema(description = "Password (min 8 characters)", example = "jakejake")
+        String password) {}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/UpdateUserRequest.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/UpdateUserRequest.java
@@ -1,9 +1,12 @@
 package com.conduit.user.adapter.in.web;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "User profile update payload (all fields optional)")
 public record UpdateUserRequest(
-    String email,
-    String username,
-    String password,
-    String bio,
-    String image
-) {}
+    @Schema(description = "New email address", example = "jake@jake.jake") String email,
+    @Schema(description = "New username", example = "jake") String username,
+    @Schema(description = "New password", example = "newpassword") String password,
+    @Schema(description = "Short bio", example = "I like to skateboard") String bio,
+    @Schema(description = "Avatar image URL", example = "https://i.stack.imgur.com/xHWG8.jpg")
+        String image) {}

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/UserController.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/UserController.java
@@ -6,6 +6,10 @@ import com.conduit.user.domain.port.in.GetCurrentUserUseCase;
 import com.conduit.user.domain.port.in.LoginUserUseCase;
 import com.conduit.user.domain.port.in.RegisterUserUseCase;
 import com.conduit.user.domain.port.in.UpdateUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "User and Authentication", description = "Register, login, and manage user profile")
 @RestController
 @RequestMapping("/api")
 public class UserController {
@@ -27,9 +32,12 @@ public class UserController {
   private final UpdateUserUseCase updateUserUseCase;
   private final JwtTokenProvider jwtTokenProvider;
 
-  public UserController(RegisterUserUseCase registerUserUseCase,
-      LoginUserUseCase loginUserUseCase, GetCurrentUserUseCase getCurrentUserUseCase,
-      UpdateUserUseCase updateUserUseCase, JwtTokenProvider jwtTokenProvider) {
+  public UserController(
+      RegisterUserUseCase registerUserUseCase,
+      LoginUserUseCase loginUserUseCase,
+      GetCurrentUserUseCase getCurrentUserUseCase,
+      UpdateUserUseCase updateUserUseCase,
+      JwtTokenProvider jwtTokenProvider) {
     this.registerUserUseCase = registerUserUseCase;
     this.loginUserUseCase = loginUserUseCase;
     this.getCurrentUserUseCase = getCurrentUserUseCase;
@@ -37,6 +45,9 @@ public class UserController {
     this.jwtTokenProvider = jwtTokenProvider;
   }
 
+  @Operation(summary = "Register a new user", description = "Create a new user account")
+  @ApiResponse(responseCode = "200", description = "User registered successfully")
+  @ApiResponse(responseCode = "422", description = "Validation error or duplicate email/username")
   @PostMapping("/users")
   public ResponseEntity<Map<String, UserResponse>> register(
       @Valid @RequestBody Map<String, RegisterRequest> body) {
@@ -46,6 +57,9 @@ public class UserController {
     return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
   }
 
+  @Operation(summary = "Login", description = "Login with email and password")
+  @ApiResponse(responseCode = "200", description = "Login successful")
+  @ApiResponse(responseCode = "401", description = "Invalid email or password")
   @PostMapping("/users/login")
   public ResponseEntity<Map<String, UserResponse>> login(
       @Valid @RequestBody Map<String, LoginRequest> body) {
@@ -55,6 +69,12 @@ public class UserController {
     return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
   }
 
+  @Operation(
+      summary = "Get current user",
+      description = "Get the currently logged-in user. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "Current user data")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
   @GetMapping("/user")
   public ResponseEntity<Map<String, UserResponse>> getCurrentUser(Authentication authentication) {
     Long userId = (Long) authentication.getPrincipal();
@@ -63,13 +83,21 @@ public class UserController {
     return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
   }
 
+  @Operation(
+      summary = "Update current user",
+      description = "Update user profile fields. Auth required.",
+      security = @SecurityRequirement(name = "Token"))
+  @ApiResponse(responseCode = "200", description = "User updated")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "422", description = "Validation error")
   @PutMapping("/user")
-  public ResponseEntity<Map<String, UserResponse>> updateUser(Authentication authentication,
-      @RequestBody Map<String, UpdateUserRequest> body) {
+  public ResponseEntity<Map<String, UserResponse>> updateUser(
+      Authentication authentication, @RequestBody Map<String, UpdateUserRequest> body) {
     Long userId = (Long) authentication.getPrincipal();
     UpdateUserRequest req = body.get("user");
-    User user = updateUserUseCase.update(userId, req.email(), req.username(), req.password(),
-        req.bio(), req.image());
+    User user =
+        updateUserUseCase.update(
+            userId, req.email(), req.username(), req.password(), req.bio(), req.image());
     String token = jwtTokenProvider.generateToken(user.getId());
     return ResponseEntity.ok(Map.of("user", UserResponse.from(user, token)));
   }

--- a/backend/src/main/java/com/conduit/user/adapter/in/web/UserResponse.java
+++ b/backend/src/main/java/com/conduit/user/adapter/in/web/UserResponse.java
@@ -1,17 +1,18 @@
 package com.conduit.user.adapter.in.web;
 
 import com.conduit.user.domain.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Authenticated user data")
 public record UserResponse(
-    String email,
-    String token,
-    String username,
-    String bio,
-    String image
-) {
+    @Schema(description = "Email address", example = "jake@jake.jake") String email,
+    @Schema(description = "JWT token", example = "eyJhbGciOiJIUzI1NiJ9...") String token,
+    @Schema(description = "Username", example = "jake") String username,
+    @Schema(description = "Short bio") String bio,
+    @Schema(description = "Avatar image URL") String image) {
 
   public static UserResponse from(User user, String token) {
-    return new UserResponse(user.getEmail(), token, user.getUsername(), user.getBio(),
-        user.getImage());
+    return new UserResponse(
+        user.getEmail(), token, user.getUsername(), user.getBio(), user.getImage());
   }
 }


### PR DESCRIPTION
## Summary
- OpenApiConfig 추가: JWT SecurityScheme (`Token` prefix) 설정
- 5 Controller에 `@Operation`, `@ApiResponse`, `@Parameter`, `@Tag` 어노테이션 추가
- 8 DTO에 `@Schema(description, example)` 추가
- Swagger UI (`/swagger-ui.html`)에서 19 엔드포인트 문서화 확인

## Test plan
- [x] `./gradlew build` BUILD SUCCESSFUL
- [x] `/v3/api-docs` JSON에 19 엔드포인트 + SecurityScheme 확인
- [x] `/swagger-ui/index.html` HTTP 200 접근 확인
- [x] 기존 테스트 전체 통과

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)