### PR TITLE
chore(backend): 최종 점검 — 로깅/에러 통일 + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,108 @@
-# board-playground
+# Conduit — RealWorld Medium Clone
 
+A full-stack implementation of the [RealWorld](https://realworld-docs.netlify.app/) "Conduit" blogging platform.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | React 18 + TypeScript 5.6 + Vite 5 + CSS Modules |
+| Backend | Java 24 + Spring Boot 3.5 + Hexagonal Architecture |
+| Database | PostgreSQL 16 (H2 for local dev) |
+| Auth | JWT (stateless, `Token` prefix) |
+| API Docs | Springdoc OpenAPI (Swagger UI) |
+| Testing | JUnit 5, Playwright E2E |
+
+## Architecture
+
+```
+backend/                       # Spring Boot (Hexagonal / Ports & Adapters)
+  src/main/java/com/conduit/
+    user/                      # User module (register, login, profile update)
+    article/                   # Article module (CRUD, feed, favorites)
+    comment/                   # Comment module (add, list, delete)
+    profile/                   # Profile module (get, follow, unfollow)
+    tag/                       # Tag module (list popular tags)
+    shared/                    # Cross-cutting (security, config, exceptions)
+
+frontend/                      # React SPA
+  src/
+    pages/                     # Route pages (home, article, editor, auth, settings, profile)
+    components/                # Shared components (favorite button, etc.)
+    api/                       # Axios API clients
+    hooks/                     # Custom hooks (useAuth)
+```
+
+## Quick Start
+
+### Prerequisites
+
+- Java 24+
+- Node.js 20 LTS + pnpm 9
+- (Optional) PostgreSQL 16 for dev/stg/prod profiles
+
+### Run locally (H2 in-memory DB)
+
+```bash
+# Backend (terminal 1)
+cd backend
+./gradlew bootRun --args='--spring.profiles.active=local'
+# -> http://localhost:8080
+
+# Frontend (terminal 2)
+cd frontend
+pnpm install
+pnpm dev
+# -> http://localhost:5174
+```
+
+### API Documentation
+
+With the backend running, open [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) for the Swagger UI.
+
+## API Endpoints (19 total)
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| POST | `/api/users` | - | Register |
+| POST | `/api/users/login` | - | Login |
+| GET | `/api/user` | Required | Get current user |
+| PUT | `/api/user` | Required | Update profile |
+| GET | `/api/articles` | - | List articles (filter by tag/author/favorited) |
+| GET | `/api/articles/feed` | Required | Feed (from followed users) |
+| POST | `/api/articles` | Required | Create article |
+| GET | `/api/articles/:slug` | - | Get article |
+| PUT | `/api/articles/:slug` | Required | Update article (author only) |
+| DELETE | `/api/articles/:slug` | Required | Delete article (author only) |
+| POST | `/api/articles/:slug/favorite` | Required | Favorite article |
+| DELETE | `/api/articles/:slug/favorite` | Required | Unfavorite article |
+| POST | `/api/articles/:slug/comments` | Required | Add comment |
+| GET | `/api/articles/:slug/comments` | - | List comments |
+| DELETE | `/api/articles/:slug/comments/:id` | Required | Delete comment (author only) |
+| GET | `/api/profiles/:username` | - | Get profile |
+| POST | `/api/profiles/:username/follow` | Required | Follow user |
+| DELETE | `/api/profiles/:username/follow` | Required | Unfollow user |
+| GET | `/api/tags` | - | List tags |
+
+## Testing
+
+```bash
+# Backend unit + integration tests
+cd backend
+./gradlew test
+
+# Frontend E2E tests (requires both FE + BE running)
+cd frontend
+pnpm exec playwright test
+```
+
+## Profiles
+
+| Profile | DB | Logging | Use case |
+|---------|-----|---------|----------|
+| `local` | H2 in-memory | DEBUG | Quick local dev (no PostgreSQL needed) |
+| `dev` | PostgreSQL `conduit_dev` | DEBUG | Full dev with persistent DB |
+| `stg` | PostgreSQL `conduit_stg` | INFO | Staging |
+| `prod` | PostgreSQL `conduit_prod` | WARN | Production |
+
+See [LOCAL.md](LOCAL.md) for detailed per-profile setup instructions.

--- a/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
+++ b/backend/src/main/java/com/conduit/article/application/service/ArticleService.java
@@ -14,6 +14,8 @@ import com.conduit.article.domain.port.out.FavoriteRepository;
 import com.conduit.article.domain.port.out.FollowRepository;
 import com.conduit.shared.exception.ApiException;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,11 +31,15 @@ public class ArticleService
         FavoriteArticleUseCase,
         UnfavoriteArticleUseCase {
 
+  private static final Logger log = LoggerFactory.getLogger(ArticleService.class);
+
   private final ArticleRepository articleRepository;
   private final FollowRepository followRepository;
   private final FavoriteRepository favoriteRepository;
 
-  public ArticleService(ArticleRepository articleRepository, FollowRepository followRepository,
+  public ArticleService(
+      ArticleRepository articleRepository,
+      FollowRepository followRepository,
       FavoriteRepository favoriteRepository) {
     this.articleRepository = articleRepository;
     this.followRepository = followRepository;
@@ -54,7 +60,9 @@ public class ArticleService
     }
     article.setSlug(slug);
 
-    return articleRepository.save(article);
+    Article saved = articleRepository.save(article);
+    log.info("Article created: slug={}, authorId={}", slug, authorId);
+    return saved;
   }
 
   @Override
@@ -104,6 +112,7 @@ public class ArticleService
     }
 
     articleRepository.delete(article);
+    log.info("Article deleted: slug={}, userId={}", slug, userId);
   }
 
   @Override

--- a/backend/src/main/java/com/conduit/comment/application/service/CommentService.java
+++ b/backend/src/main/java/com/conduit/comment/application/service/CommentService.java
@@ -7,57 +7,70 @@ import com.conduit.comment.domain.port.in.DeleteCommentUseCase;
 import com.conduit.comment.domain.port.in.ListCommentsUseCase;
 import com.conduit.comment.domain.port.out.CommentRepository;
 import com.conduit.shared.exception.ApiException;
-
+import java.time.Instant;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-import java.util.List;
-
 @Service
 @Transactional(readOnly = true)
-public class CommentService implements AddCommentUseCase, ListCommentsUseCase, DeleteCommentUseCase {
+public class CommentService
+    implements AddCommentUseCase, ListCommentsUseCase, DeleteCommentUseCase {
 
-    private final CommentRepository commentRepository;
-    private final ArticleRepository articleRepository;
+  private static final Logger log = LoggerFactory.getLogger(CommentService.class);
 
-    public CommentService(CommentRepository commentRepository, ArticleRepository articleRepository) {
-        this.commentRepository = commentRepository;
-        this.articleRepository = articleRepository;
+  private final CommentRepository commentRepository;
+  private final ArticleRepository articleRepository;
+
+  public CommentService(CommentRepository commentRepository, ArticleRepository articleRepository) {
+    this.commentRepository = commentRepository;
+    this.articleRepository = articleRepository;
+  }
+
+  @Override
+  @Transactional
+  public Comment addComment(String slug, String body, Long authorId) {
+    var article =
+        articleRepository
+            .findBySlug(slug)
+            .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
+
+    var comment = new Comment(null, body, article.getId(), authorId, Instant.now(), Instant.now());
+    Comment saved = commentRepository.save(comment);
+    log.info("Comment added: articleSlug={}, authorId={}", slug, authorId);
+    return saved;
+  }
+
+  @Override
+  public List<Comment> listComments(String slug) {
+    var article =
+        articleRepository
+            .findBySlug(slug)
+            .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
+
+    return commentRepository.findByArticleId(article.getId());
+  }
+
+  @Override
+  @Transactional
+  public void deleteComment(String slug, Long commentId, Long currentUserId) {
+    // Verify article exists
+    articleRepository
+        .findBySlug(slug)
+        .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
+
+    var comment =
+        commentRepository
+            .findById(commentId)
+            .orElseThrow(() -> new ApiException.NotFoundException("Comment not found"));
+
+    if (!comment.authorId().equals(currentUserId)) {
+      throw new ApiException.ForbiddenException("You cannot delete this comment");
     }
 
-    @Override
-    @Transactional
-    public Comment addComment(String slug, String body, Long authorId) {
-        var article = articleRepository.findBySlug(slug)
-                .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
-
-        var comment = new Comment(null, body, article.getId(), authorId, Instant.now(), Instant.now());
-        return commentRepository.save(comment);
-    }
-
-    @Override
-    public List<Comment> listComments(String slug) {
-        var article = articleRepository.findBySlug(slug)
-                .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
-
-        return commentRepository.findByArticleId(article.getId());
-    }
-
-    @Override
-    @Transactional
-    public void deleteComment(String slug, Long commentId, Long currentUserId) {
-        // Verify article exists
-        articleRepository.findBySlug(slug)
-                .orElseThrow(() -> new ApiException.NotFoundException("Article not found"));
-
-        var comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new ApiException.NotFoundException("Comment not found"));
-
-        if (!comment.authorId().equals(currentUserId)) {
-            throw new ApiException.ForbiddenException("You cannot delete this comment");
-        }
-
-        commentRepository.deleteById(commentId);
-    }
+    commentRepository.deleteById(commentId);
+    log.info("Comment deleted: id={}, userId={}", commentId, currentUserId);
+  }
 }

--- a/backend/src/main/java/com/conduit/profile/application/service/ProfileService.java
+++ b/backend/src/main/java/com/conduit/profile/application/service/ProfileService.java
@@ -6,7 +6,9 @@ import com.conduit.profile.domain.port.in.GetProfileUseCase;
 import com.conduit.profile.domain.port.in.UnfollowUserUseCase;
 import com.conduit.profile.domain.port.out.ProfileFollowRepository;
 import com.conduit.profile.domain.port.out.ProfileUserRepository;
-
+import com.conduit.shared.exception.ApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,58 +16,65 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ProfileService implements GetProfileUseCase, FollowUserUseCase, UnfollowUserUseCase {
 
-    private final ProfileUserRepository userRepository;
-    private final ProfileFollowRepository followRepository;
+  private static final Logger log = LoggerFactory.getLogger(ProfileService.class);
 
-    public ProfileService(ProfileUserRepository userRepository,
-                          ProfileFollowRepository followRepository) {
-        this.userRepository = userRepository;
-        this.followRepository = followRepository;
+  private final ProfileUserRepository userRepository;
+  private final ProfileFollowRepository followRepository;
+
+  public ProfileService(
+      ProfileUserRepository userRepository, ProfileFollowRepository followRepository) {
+    this.userRepository = userRepository;
+    this.followRepository = followRepository;
+  }
+
+  @Override
+  public Profile getProfile(String username, Long currentUserId) {
+    return userRepository
+        .findByUsername(username, currentUserId)
+        .orElseThrow(() -> new ApiException.NotFoundException("user not found"));
+  }
+
+  @Override
+  @Transactional
+  public Profile follow(String username, Long currentUserId) {
+    if (!userRepository.existsByUsername(username)) {
+      throw new ApiException.NotFoundException("user not found");
     }
 
-    @Override
-    public Profile getProfile(String username, Long currentUserId) {
-        return userRepository.findByUsername(username, currentUserId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found: " + username));
+    Long targetUserId = userRepository.findUserIdByUsername(username);
+
+    if (targetUserId.equals(currentUserId)) {
+      throw new ApiException.ValidationException("cannot follow yourself");
     }
 
-    @Override
-    @Transactional
-    public Profile follow(String username, Long currentUserId) {
-        if (!userRepository.existsByUsername(username)) {
-            throw new IllegalArgumentException("User not found: " + username);
-        }
-
-        Long targetUserId = userRepository.findUserIdByUsername(username);
-
-        if (targetUserId.equals(currentUserId)) {
-            throw new IllegalArgumentException("Cannot follow yourself");
-        }
-
-        if (!followRepository.isFollowing(currentUserId, targetUserId)) {
-            followRepository.follow(currentUserId, targetUserId);
-        }
-
-        return new Profile(username,
-                userRepository.findByUsername(username, currentUserId).orElseThrow().bio(),
-                userRepository.findByUsername(username, currentUserId).orElseThrow().image(),
-                true);
+    if (!followRepository.isFollowing(currentUserId, targetUserId)) {
+      followRepository.follow(currentUserId, targetUserId);
+      log.info("User followed: followerId={}, followee={}", currentUserId, username);
     }
 
-    @Override
-    @Transactional
-    public Profile unfollow(String username, Long currentUserId) {
-        if (!userRepository.existsByUsername(username)) {
-            throw new IllegalArgumentException("User not found: " + username);
-        }
+    return new Profile(
+        username,
+        userRepository.findByUsername(username, currentUserId).orElseThrow().bio(),
+        userRepository.findByUsername(username, currentUserId).orElseThrow().image(),
+        true);
+  }
 
-        Long targetUserId = userRepository.findUserIdByUsername(username);
-
-        followRepository.unfollow(currentUserId, targetUserId);
-
-        return new Profile(username,
-                userRepository.findByUsername(username, currentUserId).orElseThrow().bio(),
-                userRepository.findByUsername(username, currentUserId).orElseThrow().image(),
-                false);
+  @Override
+  @Transactional
+  public Profile unfollow(String username, Long currentUserId) {
+    if (!userRepository.existsByUsername(username)) {
+      throw new ApiException.NotFoundException("user not found");
     }
+
+    Long targetUserId = userRepository.findUserIdByUsername(username);
+
+    followRepository.unfollow(currentUserId, targetUserId);
+    log.info("User unfollowed: followerId={}, followee={}", currentUserId, username);
+
+    return new Profile(
+        username,
+        userRepository.findByUsername(username, currentUserId).orElseThrow().bio(),
+        userRepository.findByUsername(username, currentUserId).orElseThrow().image(),
+        false);
+  }
 }

--- a/backend/src/main/java/com/conduit/shared/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/conduit/shared/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,8 +16,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
   @ExceptionHandler(ApiException.class)
   public ResponseEntity<ErrorResponse> handleApiException(ApiException ex) {
+    log.warn("API error [{}]: {}", ex.getStatus().value(), ex.getMessage());
     ErrorResponse response = ErrorResponse.of("body", ex.getMessage());
     return ResponseEntity.status(ex.getStatus()).body(response);
   }
@@ -31,6 +36,7 @@ public class GlobalExceptionHandler {
                   .computeIfAbsent(fieldError.getField(), k -> new ArrayList<>())
                   .add(fieldError.getDefaultMessage());
             });
+    log.warn("Validation error: {}", errors);
     return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ErrorResponse.of(errors));
   }
 
@@ -48,12 +54,14 @@ public class GlobalExceptionHandler {
       }
     }
 
+    log.warn("Data integrity violation: field={}", field);
     ErrorResponse response = ErrorResponse.of(field, "has already been taken");
     return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(response);
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleGeneral(Exception ex) {
+    log.error("Unexpected error", ex);
     ErrorResponse response = ErrorResponse.of("server", "internal server error");
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
   }

--- a/backend/src/main/java/com/conduit/user/application/service/UserService.java
+++ b/backend/src/main/java/com/conduit/user/application/service/UserService.java
@@ -7,6 +7,8 @@ import com.conduit.user.domain.port.in.LoginUserUseCase;
 import com.conduit.user.domain.port.in.RegisterUserUseCase;
 import com.conduit.user.domain.port.in.UpdateUserUseCase;
 import com.conduit.user.domain.port.out.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserService
     implements RegisterUserUseCase, LoginUserUseCase, GetCurrentUserUseCase, UpdateUserUseCase {
+
+  private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
@@ -34,39 +38,49 @@ public class UserService
     }
 
     User user = User.create(email, username, passwordEncoder.encode(password));
-    return userRepository.save(user);
+    User saved = userRepository.save(user);
+    log.info("User registered: username={}", username);
+    return saved;
   }
 
   @Override
   @Transactional(readOnly = true)
   public User login(String email, String password) {
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new ApiException.UnauthorizedException("invalid email or password"));
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new ApiException.UnauthorizedException("invalid email or password"));
 
     if (!passwordEncoder.matches(password, user.getPassword())) {
+      log.warn("Login failed: invalid password for email={}", email);
       throw new ApiException.UnauthorizedException("invalid email or password");
     }
 
+    log.info("User logged in: email={}", email);
     return user;
   }
 
   @Override
   @Transactional(readOnly = true)
   public User getCurrentUser(Long userId) {
-    return userRepository.findById(userId)
+    return userRepository
+        .findById(userId)
         .orElseThrow(() -> new ApiException.NotFoundException("user not found"));
   }
 
   @Override
-  public User update(Long userId, String email, String username, String password, String bio,
-      String image) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new ApiException.NotFoundException("user not found"));
+  public User update(
+      Long userId, String email, String username, String password, String bio, String image) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new ApiException.NotFoundException("user not found"));
 
     if (email != null && !email.equals(user.getEmail()) && userRepository.existsByEmail(email)) {
       throw new ApiException.ValidationException("email has already been taken");
     }
-    if (username != null && !username.equals(user.getUsername())
+    if (username != null
+        && !username.equals(user.getUsername())
         && userRepository.existsByUsername(username)) {
       throw new ApiException.ValidationException("username has already been taken");
     }

--- a/backend/src/test/java/com/conduit/profile/ProfileIntegrationTest.java
+++ b/backend/src/test/java/com/conduit/profile/ProfileIntegrationTest.java
@@ -1,21 +1,20 @@
 package com.conduit.profile;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.conduit.shared.security.JwtTokenProvider;
 import com.conduit.user.adapter.out.persistence.UserJpaEntity;
 import com.conduit.user.adapter.out.persistence.UserJpaRepository;
-import com.conduit.shared.security.JwtTokenProvider;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -23,107 +22,110 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 class ProfileIntegrationTest {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private UserJpaRepository userRepository;
-    @Autowired private JwtTokenProvider jwtTokenProvider;
-    @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private UserJpaRepository userRepository;
+  @Autowired private JwtTokenProvider jwtTokenProvider;
+  @Autowired private PasswordEncoder passwordEncoder;
 
-    private UserJpaEntity user1;
-    private UserJpaEntity user2;
-    private String token1;
+  private UserJpaEntity user1;
+  private UserJpaEntity user2;
+  private String token1;
 
-    @BeforeEach
-    void setUp() {
-        user1 = userRepository.save(
-                new UserJpaEntity("user1@test.com", "user1", passwordEncoder.encode("pass"), null, null));
-        token1 = jwtTokenProvider.generateToken(user1.getId());
+  @BeforeEach
+  void setUp() {
+    user1 =
+        userRepository.save(
+            new UserJpaEntity(
+                "user1@test.com", "user1", passwordEncoder.encode("pass"), null, null));
+    token1 = jwtTokenProvider.generateToken(user1.getId());
 
-        user2 = userRepository.save(
-                new UserJpaEntity("user2@test.com", "user2", passwordEncoder.encode("pass"), null, null));
-    }
+    user2 =
+        userRepository.save(
+            new UserJpaEntity(
+                "user2@test.com", "user2", passwordEncoder.encode("pass"), null, null));
+  }
 
-    @Test
-    void getProfile_unauthenticated_returnsFollowingFalse() throws Exception {
-        mockMvc.perform(get("/api/profiles/user2"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.profile.username").value("user2"))
-                .andExpect(jsonPath("$.profile.following").value(false));
-    }
+  @Test
+  void getProfile_unauthenticated_returnsFollowingFalse() throws Exception {
+    mockMvc
+        .perform(get("/api/profiles/user2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.profile.username").value("user2"))
+        .andExpect(jsonPath("$.profile.following").value(false));
+  }
 
-    @Test
-    void getProfile_authenticated_returnsFollowingFalse() throws Exception {
-        mockMvc.perform(get("/api/profiles/user2")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.profile.username").value("user2"))
-                .andExpect(jsonPath("$.profile.following").value(false));
-    }
+  @Test
+  void getProfile_authenticated_returnsFollowingFalse() throws Exception {
+    mockMvc
+        .perform(get("/api/profiles/user2").header("Authorization", "Token " + token1))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.profile.username").value("user2"))
+        .andExpect(jsonPath("$.profile.following").value(false));
+  }
 
-    @Test
-    void getProfile_notFound_returns500() throws Exception {
-        mockMvc.perform(get("/api/profiles/nonexistent"))
-                .andExpect(status().is5xxServerError());
-    }
+  @Test
+  void getProfile_notFound_returns404() throws Exception {
+    mockMvc.perform(get("/api/profiles/nonexistent")).andExpect(status().isNotFound());
+  }
 
-    @Test
-    void follow_thenGetProfile_returnsFollowingTrue() throws Exception {
-        mockMvc.perform(post("/api/profiles/user2/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.profile.username").value("user2"))
-                .andExpect(jsonPath("$.profile.following").value(true));
+  @Test
+  void follow_thenGetProfile_returnsFollowingTrue() throws Exception {
+    mockMvc
+        .perform(post("/api/profiles/user2/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.profile.username").value("user2"))
+        .andExpect(jsonPath("$.profile.following").value(true));
 
-        // Verify via GET
-        mockMvc.perform(get("/api/profiles/user2")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(jsonPath("$.profile.following").value(true));
-    }
+    // Verify via GET
+    mockMvc
+        .perform(get("/api/profiles/user2").header("Authorization", "Token " + token1))
+        .andExpect(jsonPath("$.profile.following").value(true));
+  }
 
-    @Test
-    void follow_idempotent() throws Exception {
-        mockMvc.perform(post("/api/profiles/user2/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().isOk());
+  @Test
+  void follow_idempotent() throws Exception {
+    mockMvc
+        .perform(post("/api/profiles/user2/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isOk());
 
-        // Follow again — should still succeed
-        mockMvc.perform(post("/api/profiles/user2/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.profile.following").value(true));
-    }
+    // Follow again — should still succeed
+    mockMvc
+        .perform(post("/api/profiles/user2/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.profile.following").value(true));
+  }
 
-    @Test
-    void unfollow_afterFollow_returnsFollowingFalse() throws Exception {
-        // Follow first
-        mockMvc.perform(post("/api/profiles/user2/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().isOk());
+  @Test
+  void unfollow_afterFollow_returnsFollowingFalse() throws Exception {
+    // Follow first
+    mockMvc
+        .perform(post("/api/profiles/user2/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isOk());
 
-        // Unfollow
-        mockMvc.perform(delete("/api/profiles/user2/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.profile.username").value("user2"))
-                .andExpect(jsonPath("$.profile.following").value(false));
-    }
+    // Unfollow
+    mockMvc
+        .perform(delete("/api/profiles/user2/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.profile.username").value("user2"))
+        .andExpect(jsonPath("$.profile.following").value(false));
+  }
 
-    @Test
-    void follow_unauthenticated_returns401() throws Exception {
-        mockMvc.perform(post("/api/profiles/user2/follow"))
-                .andExpect(status().isUnauthorized());
-    }
+  @Test
+  void follow_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(post("/api/profiles/user2/follow")).andExpect(status().isUnauthorized());
+  }
 
-    @Test
-    void follow_nonexistentUser_returns500() throws Exception {
-        mockMvc.perform(post("/api/profiles/ghost/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().is5xxServerError());
-    }
+  @Test
+  void follow_nonexistentUser_returns404() throws Exception {
+    mockMvc
+        .perform(post("/api/profiles/ghost/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isNotFound());
+  }
 
-    @Test
-    void follow_self_returns500() throws Exception {
-        mockMvc.perform(post("/api/profiles/user1/follow")
-                        .header("Authorization", "Token " + token1))
-                .andExpect(status().is5xxServerError());
-    }
+  @Test
+  void follow_self_returns422() throws Exception {
+    mockMvc
+        .perform(post("/api/profiles/user1/follow").header("Authorization", "Token " + token1))
+        .andExpect(status().isUnprocessableEntity());
+  }
 }

--- a/backend/src/test/java/com/conduit/profile/application/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/conduit/profile/application/service/ProfileServiceTest.java
@@ -1,108 +1,107 @@
 package com.conduit.profile.application.service;
 
-import com.conduit.profile.domain.model.Profile;
-import com.conduit.profile.domain.port.out.ProfileFollowRepository;
-import com.conduit.profile.domain.port.out.ProfileUserRepository;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+import com.conduit.profile.domain.model.Profile;
+import com.conduit.profile.domain.port.out.ProfileFollowRepository;
+import com.conduit.profile.domain.port.out.ProfileUserRepository;
+import com.conduit.shared.exception.ApiException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 class ProfileServiceTest {
 
-    private ProfileUserRepository userRepository;
-    private ProfileFollowRepository followRepository;
-    private ProfileService service;
+  private ProfileUserRepository userRepository;
+  private ProfileFollowRepository followRepository;
+  private ProfileService service;
 
-    @BeforeEach
-    void setUp() {
-        userRepository = mock(ProfileUserRepository.class);
-        followRepository = mock(ProfileFollowRepository.class);
-        service = new ProfileService(userRepository, followRepository);
-    }
+  @BeforeEach
+  void setUp() {
+    userRepository = mock(ProfileUserRepository.class);
+    followRepository = mock(ProfileFollowRepository.class);
+    service = new ProfileService(userRepository, followRepository);
+  }
 
-    @Test
-    void getProfile_returnsProfile() {
-        Profile expected = new Profile("jake", "bio", "img.png", false);
-        when(userRepository.findByUsername("jake", 1L)).thenReturn(Optional.of(expected));
+  @Test
+  void getProfile_returnsProfile() {
+    Profile expected = new Profile("jake", "bio", "img.png", false);
+    when(userRepository.findByUsername("jake", 1L)).thenReturn(Optional.of(expected));
 
-        Profile result = service.getProfile("jake", 1L);
+    Profile result = service.getProfile("jake", 1L);
 
-        assertThat(result.username()).isEqualTo("jake");
-        assertThat(result.following()).isFalse();
-    }
+    assertThat(result.username()).isEqualTo("jake");
+    assertThat(result.following()).isFalse();
+  }
 
-    @Test
-    void getProfile_userNotFound_throws() {
-        when(userRepository.findByUsername("ghost", null)).thenReturn(Optional.empty());
+  @Test
+  void getProfile_userNotFound_throws() {
+    when(userRepository.findByUsername("ghost", null)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.getProfile("ghost", null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("User not found");
-    }
+    assertThatThrownBy(() -> service.getProfile("ghost", null))
+        .isInstanceOf(ApiException.NotFoundException.class)
+        .hasMessageContaining("user not found");
+  }
 
-    @Test
-    void follow_createsFollow_returnsFollowingTrue() {
-        when(userRepository.existsByUsername("jake")).thenReturn(true);
-        when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
-        when(followRepository.isFollowing(1L, 2L)).thenReturn(false);
-        when(userRepository.findByUsername("jake", 1L))
-                .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", true)));
+  @Test
+  void follow_createsFollow_returnsFollowingTrue() {
+    when(userRepository.existsByUsername("jake")).thenReturn(true);
+    when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
+    when(followRepository.isFollowing(1L, 2L)).thenReturn(false);
+    when(userRepository.findByUsername("jake", 1L))
+        .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", true)));
 
-        Profile result = service.follow("jake", 1L);
+    Profile result = service.follow("jake", 1L);
 
-        assertThat(result.following()).isTrue();
-        verify(followRepository).follow(1L, 2L);
-    }
+    assertThat(result.following()).isTrue();
+    verify(followRepository).follow(1L, 2L);
+  }
 
-    @Test
-    void follow_alreadyFollowing_idempotent() {
-        when(userRepository.existsByUsername("jake")).thenReturn(true);
-        when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
-        when(followRepository.isFollowing(1L, 2L)).thenReturn(true);
-        when(userRepository.findByUsername("jake", 1L))
-                .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", true)));
+  @Test
+  void follow_alreadyFollowing_idempotent() {
+    when(userRepository.existsByUsername("jake")).thenReturn(true);
+    when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
+    when(followRepository.isFollowing(1L, 2L)).thenReturn(true);
+    when(userRepository.findByUsername("jake", 1L))
+        .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", true)));
 
-        Profile result = service.follow("jake", 1L);
+    Profile result = service.follow("jake", 1L);
 
-        assertThat(result.following()).isTrue();
-        verify(followRepository, never()).follow(anyLong(), anyLong());
-    }
+    assertThat(result.following()).isTrue();
+    verify(followRepository, never()).follow(anyLong(), anyLong());
+  }
 
-    @Test
-    void follow_self_throws() {
-        when(userRepository.existsByUsername("me")).thenReturn(true);
-        when(userRepository.findUserIdByUsername("me")).thenReturn(1L);
+  @Test
+  void follow_self_throws() {
+    when(userRepository.existsByUsername("me")).thenReturn(true);
+    when(userRepository.findUserIdByUsername("me")).thenReturn(1L);
 
-        assertThatThrownBy(() -> service.follow("me", 1L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Cannot follow yourself");
-    }
+    assertThatThrownBy(() -> service.follow("me", 1L))
+        .isInstanceOf(ApiException.ValidationException.class)
+        .hasMessageContaining("cannot follow yourself");
+  }
 
-    @Test
-    void unfollow_removesFollow_returnsFollowingFalse() {
-        when(userRepository.existsByUsername("jake")).thenReturn(true);
-        when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
-        when(userRepository.findByUsername("jake", 1L))
-                .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", false)));
+  @Test
+  void unfollow_removesFollow_returnsFollowingFalse() {
+    when(userRepository.existsByUsername("jake")).thenReturn(true);
+    when(userRepository.findUserIdByUsername("jake")).thenReturn(2L);
+    when(userRepository.findByUsername("jake", 1L))
+        .thenReturn(Optional.of(new Profile("jake", "bio", "img.png", false)));
 
-        Profile result = service.unfollow("jake", 1L);
+    Profile result = service.unfollow("jake", 1L);
 
-        assertThat(result.following()).isFalse();
-        verify(followRepository).unfollow(1L, 2L);
-    }
+    assertThat(result.following()).isFalse();
+    verify(followRepository).unfollow(1L, 2L);
+  }
 
-    @Test
-    void unfollow_userNotFound_throws() {
-        when(userRepository.existsByUsername("ghost")).thenReturn(false);
+  @Test
+  void unfollow_userNotFound_throws() {
+    when(userRepository.existsByUsername("ghost")).thenReturn(false);
 
-        assertThatThrownBy(() -> service.unfollow("ghost", 1L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("User not found");
-    }
+    assertThatThrownBy(() -> service.unfollow("ghost", 1L))
+        .isInstanceOf(ApiException.NotFoundException.class)
+        .hasMessageContaining("user not found");
+  }
 }


### PR DESCRIPTION
## Summary
- 4 Service + GlobalExceptionHandler에 SLF4J 로거 추가 (INFO/WARN/ERROR 적절 배치)
- ProfileService: `IllegalArgumentException` → `ApiException.NotFoundException/ValidationException` 통일 (500→404/422)
- README.md 작성: 기술스택, 아키텍처, Quick Start, 19 API 엔드포인트, 프로파일 표

## Test plan
- [x] `./gradlew build` BUILD SUCCESSFUL (196 tests, 0 failures)
- [x] `pnpm build` 성공
- [x] ProfileService 에러 통일 후 관련 테스트 수정 및 통과
  - ProfileIntegrationTest: 500 → 404/422 검증
  - ProfileServiceTest: IllegalArgumentException → ApiException 검증

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)