### PR TITLE
feat(plugin): code-explainer plugin with Discussion+Wiki dual sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ frontend/test-results/
 
 # TypeScript incremental build info (regenerated on build)
 frontend/tsconfig.tsbuildinfo
+
+# code-explainer plugin runtime output (uploaded to Discussion/Wiki, not tracked)
+code-explainer-plugin/output/

--- a/code-explainer-plugin/.claude-plugin/plugin.json
+++ b/code-explainer-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "code-explainer",
+  "description": "코드를 3단계 스캐폴딩(L1/L2/L3)으로 분석하여 GitHub Discussion에 적재하는 플러그인",
+  "author": {
+    "name": "Sungjun Choi"
+  }
+}

--- a/code-explainer-plugin/LICENSE
+++ b/code-explainer-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sungjun Choi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/code-explainer-plugin/README.md
+++ b/code-explainer-plugin/README.md
@@ -1,0 +1,144 @@
+# code-explainer Plugin
+
+코드를 **3단계 스캐폴딩(L1 Architecture / L2 Modules / L3 Code)**으로 분석하여 주니어 개발자용 학습 문서를 생성하고, **GitHub Discussion + Wiki에 동시 적재**하는 Claude Code 플러그인입니다.
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/code) CLI 설치
+- [GitHub CLI (`gh`)](https://cli.github.com/) 설치 및 인증 (`gh auth login`)
+- Discussion이 활성화된 GitHub 저장소
+- (선택) Wiki가 활성화되고 첫 페이지가 1개 이상 만들어진 저장소 — Wiki에도 동시 적재하려면 필요. 첫 페이지는 `https://github.com/<owner>/<repo>/wiki`의 "Create the first page"로 한 번만 만들면 됩니다. 없으면 Discussion만 적재됩니다.
+
+## 설치
+
+```bash
+# 1. 플러그인 클론
+git clone https://github.com/sungjunchoi-bespin/code-explainer-plugin.git
+
+# 2. 설정 파일 수정
+cd code-explainer-plugin
+vi config.json
+```
+
+`config.json`에 자신의 저장소 정보를 입력합니다:
+
+```json
+{
+  "discussion_repo_owner": "my-org",
+  "discussion_repo_name": "my-code-docs",
+  "webhook_url": ""
+}
+```
+
+| 항목 | 설명 | 필수 |
+|------|------|------|
+| `discussion_repo_owner` | Discussion이 활성화된 GitHub 저장소 소유자 | O |
+| `discussion_repo_name` | Discussion이 활성화된 GitHub 저장소 이름 | O |
+| `webhook_url` | Google Chat Webhook URL (비어있으면 알림 스킵) | X |
+
+```bash
+# 3. 플러그인 로드하여 Claude Code 실행
+claude --plugin-dir ./code-explainer-plugin
+```
+
+## 사용법
+
+Claude Code 안에서 슬래시 커맨드로 실행합니다:
+
+```
+# 전체 저장소 분석
+/code-explainer https://github.com/my-org/my-project
+
+# 특정 폴더 분석
+/code-explainer src/auth/
+
+# 단일 파일 분석
+/code-explainer src/auth/AuthService.java
+```
+
+자연어로도 요청 가능합니다:
+
+```
+"이 코드 분석해줘"
+"src/auth/ 설명해줘"
+```
+
+## 동작 방식
+
+요청하면 **중간 확인 없이 끝까지 자동 실행**됩니다.
+
+```
+작업 지시 (파일 경로 / Git URL)
+    │
+    ▼
+code-explainer 스킬
+    │
+    ├─ Phase 0:   설정 확인 (config.json + gh 인증 + Discussion 활성화 + Wiki 초기화)
+    ├─ Step 1~5:  코드 스캔 → L1 → L2(디렉토리별) → L3(파일별) 문서 생성
+    ├─ Phase 3:   Label 자동 생성 + General 카테고리에 Discussion 적재
+    ├─ Phase 3.5: Wiki repo clone + L1/L2/L3 페이지 작성 + Home/_Sidebar 생성 + push
+    │             (Wiki 초기화 안 됐으면 이 단계만 스킵)
+    ├─ Phase 4:   PR 코멘트에 Discussion + Wiki 링크 추가 (PR이 있을 때만)
+    └─ Phase 5:   Google Chat 알림 (webhook_url이 있을 때만)
+```
+
+## Discussion / Wiki 구조
+
+소스 코드의 디렉토리 구조를 그대로 반영합니다:
+
+| 레벨 | 단위 | 설명 |
+|------|------|------|
+| L1 · Architecture | 프로젝트 1개 | 전체 아키텍처, 데이터 흐름, 기술 선택 |
+| L2 · Modules | 디렉토리마다 1개 | 패키지 책임, 파일 목록, 의존 관계 |
+| L3 · Code | 소스 파일마다 1개 | **함수/메서드 블록마다** 코드+설명 + 주니어 팁 |
+
+### Discussion 측
+
+모든 Discussion은 **General** 카테고리에 생성되고, **Label**로 분류됩니다.
+
+### Wiki 측
+
+Wiki는 평면 구조이므로 파일명 prefix로 분류합니다:
+
+| 파일명 | 용도 |
+|--------|------|
+| `L1-<프로젝트>.md` | L1 페이지 1개 |
+| `L2-<패키지-경로>.md` | 디렉토리마다 1개 |
+| `L3-<패키지-경로>-<파일명>.md` | 소스 파일마다 1개 |
+| `Home.md` | 진입 페이지 (L1/L2/L3 전체 인덱스) |
+| `_Sidebar.md` | 좌측 네비게이션 (모든 페이지에 자동 표시) |
+
+버전 이력은 Discussion은 코멘트 백업으로, Wiki는 git history로 자동 누적됩니다.
+
+Discussion Label 색상:
+
+| Label | 용도 | 색상 |
+|-------|------|------|
+| `L1` | 아키텍처 레벨 | 빨강 `d73a4a` |
+| `L2` | 모듈 레벨 | 파랑 `0075ca` |
+| `L3` | 코드 레벨 | 초록 `008672` |
+| 프로젝트명 | 프로젝트 구분 | 노랑 `e4e669` |
+
+GitHub UI에서 Label로 필터링:
+
+```
+label:L2 label:my-project     → 모듈(디렉토리) 문서만
+label:L3 label:my-project     → 소스 파일 문서만
+```
+
+## 버전 관리
+
+- **Discussion**: 업데이트 시 이전 본문은 Comment로 보관되어 이력이 누적됩니다.
+- **Wiki**: git history로 자동 누적되며 페이지 우측 상단 "Revisions" 탭에서 과거 버전 비교 가능.
+
+```
+> 📌 v2 · 2026-05-08 11:32:04
+```
+
+## 전체 프로젝트 문서
+
+Discussion 구조, 각 레벨별 필수 포함 내용, 프로젝트 구조 등 자세한 내용은 [메인 README](https://github.com/sungjunchoi-bespin/code-explainer#readme)를 참고하세요.
+
+## License
+
+MIT

--- a/code-explainer-plugin/config.json
+++ b/code-explainer-plugin/config.json
@@ -1,0 +1,5 @@
+{
+  "discussion_repo_owner": "sungjunchoi-bespin",
+  "discussion_repo_name": "board-playground",
+  "webhook_url": ""
+}

--- a/code-explainer-plugin/skills/code-explainer/SKILL.md
+++ b/code-explainer-plugin/skills/code-explainer/SKILL.md
@@ -1,0 +1,739 @@
+---
+name: code-explainer
+description: >
+  코드를 주니어 개발자가 이해할 수 있도록 3단계 스캐폴딩 설명을 생성하고, GitHub Discussion과 Wiki에 동시에 적재합니다.
+  "이 코드 설명해줘", "주니어가 이해할 수 있게 정리해줘" 등의 요청 시 이 스킬을 사용하세요.
+argument-hint: <폴더 경로 | 파일 경로 | Git 주소>
+allowed-tools: [Read, Glob, Grep, Bash, Agent, Write, Edit]
+---
+
+# /code-explainer
+
+코드를 **3단계 스캐폴딩**으로 분해하여 주니어 개발자가 학습할 수 있는 설명 문서를 생성합니다.
+**Discussion 구조는 프로젝트의 디렉토리 구조를 그대로 반영합니다.**
+**레벨과 프로젝트 구분은 Discussion에서는 Label, Wiki에서는 페이지 prefix로 처리하여 수동 세팅이 필요 없습니다.**
+
+생성된 문서는 두 개의 sink에 동시 적재됩니다:
+
+1. **GitHub Discussions** — 라벨 기반 분류, 코멘트로 버전 이력 누적
+2. **GitHub Wiki** — `Home.md` + `_Sidebar.md`로 탐색, git history로 버전 이력 자동 누적
+
+**모든 출력은 한국어로 작성합니다.**
+
+## Usage
+
+```
+/code-explainer <폴더 경로 | 파일 경로 | Git 주소>
+```
+
+---
+
+## Phase 0: 설정 확인 (분석 전 필수)
+
+분석을 시작하기 **전에** 아래를 순서대로 확인합니다. 하나라도 실패하면 분석을 시작하지 않습니다.
+
+### 1. config.json 확인
+
+!cat "${CLAUDE_SKILL_DIR}/../../config.json"
+
+위 `config.json`을 확인합니다:
+
+- **`discussion_repo_owner` 또는 `discussion_repo_name`이 비어있으면**:
+  1. 사용자에게 Discussion을 적재할 GitHub 저장소 **owner**와 **이름**을 입력받습니다 (필수)
+  2. Google Chat Webhook URL을 입력받습니다 (선택 — 비어있으면 알림 스킵)
+  3. 입력받은 값을 `${CLAUDE_SKILL_DIR}/../../config.json`에 저장합니다
+- 값이 이미 채워져 있으면 그대로 사용합니다
+
+**필수값이 비어있으면** 아래 메시지를 반환하고 파이프라인을 중단합니다:
+
+```
+⚠️ config.json 설정이 필요합니다.
+플러그인 디렉토리의 config.json에서 아래 값을 설정해주세요:
+- discussion_repo_owner: GitHub 저장소 소유자
+- discussion_repo_name: GitHub 저장소 이름
+```
+
+### 2. GitHub CLI 인증 확인
+
+`gh auth status`를 실행합니다. 인증이 안 되어있으면 `gh auth login`을 안내하고 **중단**합니다.
+
+### 3. Discussion 활성화 확인
+
+대상 저장소에 Discussion이 활성화되어 있는지 확인합니다.
+활성화되어 있지 않으면 Settings → Features → Discussions 활성화를 안내하고 **중단**합니다.
+
+### 4. Wiki 활성화 + 초기화 확인 (선택적 — 실패 시 Wiki만 스킵)
+
+Wiki는 **Discussion과 달리 GraphQL API가 없어** `<repo>.wiki.git`을 클론·푸시하는 방식으로 적재합니다.
+따라서 사전 조건이 두 단계로 나뉩니다:
+
+1. **Wiki 기능 활성화 여부** (`has_wiki`):
+   ```bash
+   gh api repos/${OWNER}/${REPO} --jq '.has_wiki'
+   ```
+   `false`면 Settings → Features → Wikis 체크를 안내하고 **Wiki Phase만 스킵** (Discussion은 계속 진행).
+
+2. **Wiki repo 초기화 여부** (`<repo>.wiki.git` 존재):
+   ```bash
+   git ls-remote https://github.com/${OWNER}/${REPO}.wiki.git 2>&1 | head -1
+   ```
+   `Repository not found`가 나오면 wiki repo가 아직 생성되지 않은 상태입니다.
+   **GitHub Wiki는 첫 페이지를 UI에서 한 번 수동으로 만들어야 wiki repo가 초기화**됩니다.
+   초기화 안 됐으면 아래 안내를 출력하고 **Wiki Phase만 스킵** (Discussion은 계속 진행):
+
+   ```
+   ℹ️ Wiki repo가 아직 초기화되지 않았습니다.
+   https://github.com/${OWNER}/${REPO}/wiki 에서 "Create the first page" 버튼으로
+   아무 페이지 1개를 만든 뒤 다시 실행하면 Wiki에도 적재됩니다.
+   이번 실행은 Discussion만 적재합니다.
+   ```
+
+> Discussion 사전 조건이 통과되면 코드 분석을 시작합니다. Wiki 사전 조건은 실패해도 Discussion 적재는 계속되며, Phase 3.5만 스킵됩니다.
+
+---
+
+## 핵심 원칙
+
+### 1. 디렉토리 = Discussion
+
+- **L1** (1개) = 프로젝트 전체 아키텍처
+- **L2** (디렉토리마다 1개) = 소스 파일이 존재하는 모든 패키지/디렉토리
+- **L3** (소스 파일마다 1개) = 모든 소스 파일 (DTO, Router, 유틸 포함, 예외 없음)
+
+### 2. Label = 자동 분류 (수동 세팅 없음)
+
+모든 Discussion은 **General** 카테고리(기본 제공)에 생성하고, **Label**로 레벨과 프로젝트를 구분합니다.
+Category 수동 생성이 필요 없어 어떤 저장소에서든 Discussion만 활성화되어 있으면 바로 작동합니다.
+
+| Label | 용도 | 예시 |
+|-------|------|------|
+| `L1` | 아키텍처 레벨 | `L1` |
+| `L2` | 모듈(디렉토리) 레벨 | `L2` |
+| `L3` | 코드(파일) 레벨 | `L3` |
+| 프로젝트명 | 프로젝트 구분 | `t2s-admin-backend` |
+
+**GitHub UI에서 필터링:**
+```
+label:L2 label:t2s-admin-backend     → T2S의 모듈만
+label:L3 label:t2s-admin-backend     → T2S의 소스 파일만
+label:claude-code                     → Claude Code 전체
+```
+
+### 예시: Java Modulith 프로젝트
+
+```
+소스 디렉토리 구조                          → Discussion + Labels
+─────────────────────────────────────────────────────────────────
+com/cognet9/modulith/                       → 🏗️ 전체 구조 [L1] [t2s-admin-backend]
+├── core/config/security/                   → 📦 core.config.security [L2] [t2s-admin-backend]
+│   ├── SecurityConfig.java                 → 🔬 core...security/SecurityConfig.java [L3] [t2s-admin-backend]
+│   ├── AuthContext.java                    → 🔬 core...security/AuthContext.java [L3] [t2s-admin-backend]
+│   └── jwt/                                → 📦 core.config.security.jwt [L2] [t2s-admin-backend]
+│       ├── JwtTokenProvider.java           → 🔬 core...jwt/JwtTokenProvider.java [L3] [t2s-admin-backend]
+│       └── JwtAuthenticationFilter.java    → 🔬 core...jwt/JwtAuthenticationFilter.java [L3] [t2s-admin-backend]
+├── modules/account/
+│   ├── adapter/in/web/                     → 📦 modules.account.adapter.in.web [L2] [t2s-admin-backend]
+│   │   ├── AccountHandler.java             → 🔬 ...web/AccountHandler.java [L3] [t2s-admin-backend]
+│   │   └── AccountRouter.java              → 🔬 ...web/AccountRouter.java [L3] [t2s-admin-backend]
+│   ├── application/service/                → 📦 modules.account.application.service [L2] [t2s-admin-backend]
+│   │   └── AccountService.java             → 🔬 ...service/AccountService.java [L3] [t2s-admin-backend]
+│   └── model/dto/                          → 📦 modules.account.model.dto [L2] [t2s-admin-backend]
+│       ├── AccountDto.java                 → 🔬 ...dto/AccountDto.java [L3] [t2s-admin-backend]
+│       └── CreateAccountRequest.java       → 🔬 ...dto/CreateAccountRequest.java [L3] [t2s-admin-backend]
+```
+
+---
+
+## 설정 정보
+
+이 스킬은 플러그인 `config.json`에서 설정을 읽습니다.
+
+| 항목 | config.json 키 | 설명 |
+|------|----------------|------|
+| Discussion 대상 저장소 owner | `discussion_repo_owner` | GitHub 저장소 소유자 (예: `my-org`) |
+| Discussion 대상 저장소 name | `discussion_repo_name` | GitHub 저장소 이름 (예: `my-code-docs`) |
+| Google Chat Webhook URL | `webhook_url` | 비어있으면 Phase 5 스킵 |
+
+> **중요**: 업로드 스크립트 생성 시, config.json 값을 **Python 변수에 직접 삽입**합니다.
+> 런타임에 config.json을 읽지 마세요 — 실행 경로에 따라 파일을 찾지 못할 수 있습니다.
+
+```python
+# ✅ 올바른 방법: Phase 0에서 확인된 실제 값을 직접 삽입
+OWNER = "my-org"
+REPO = "my-code-docs"
+WEBHOOK_URL = "https://chat.googleapis.com/..."  # 비어있으면 ""
+
+# ❌ 잘못된 방법: 런타임에 config.json 읽기 (경로 문제 발생)
+# with open("config.json") as f: config = json.load(f)
+```
+
+---
+
+## 코드 리뷰 기준 매핑
+
+| 코드 리뷰 필수 요소 | 주로 다루는 레벨 |
+|-------------------|----------------|
+| #3 작고 집중된 단위의 PR | Step 1 스캔 (범위 경고) |
+| #4 명확한 PR 설명 (What·Why) | L1 |
+| #6 설계 검토 | L1, L2 |
+| #8 복잡성 검토 / #9 네이밍 검토 | L2 |
+| #7 기능성 / #10 오류 처리 / #11 보안 | L3 |
+| #12·13 테스트 포함·품질 | L2, L3 |
+| #14 코딩 표준·스타일 / #15 주석·문서화 | L3 |
+
+---
+
+## 분석 및 생성 단계
+
+### Step 1 · 코드 스캔
+
+1. **프로젝트명 추출**: Git URL 또는 디렉토리명에서 → Label 이름 결정
+2. **디렉토리 트리 추출** — 소스 파일이 있는 모든 디렉토리를 나열 → L2 목록 확정
+3. **소스 파일 전수 목록** — 모든 소스 파일을 나열 → L3 목록 확정 (예외 없음)
+4. **도메인 결정** — 프로젝트가 무엇인가 → L1 Section 이름
+
+### Step 2 · 코드 읽기
+
+모든 소스 파일을 읽어서 분석합니다. 파일 수가 많으면 병렬로 읽습니다.
+
+### Step 3 · L1 생성 — 전체 지도 (1개)
+
+### Step 4 · L2 생성 — 디렉토리마다 1개
+
+소스 파일이 존재하는 **모든 디렉토리(패키지)**마다 L2 Discussion을 생성합니다.
+Discussion 제목에 패키지 경로를 포함하여 프로젝트 구조가 그대로 보이도록 합니다.
+
+### Step 5 · L3 생성 — 소스 파일마다 1개
+
+**모든 소스 파일**에 대해 L3 Discussion을 생성합니다.
+DTO, Router, 보일러플레이트, 단순 유틸 등을 포함하여 **예외 없이 전부** 생성합니다.
+Discussion 제목에 패키지 경로와 파일명을 포함합니다.
+
+---
+
+## 출력 템플릿
+
+### L1 · Architecture
+
+```markdown
+## 🏗️ [프로젝트명] 전체 구조
+
+> Section: [도메인] · Level: L1 · Architecture
+> 리뷰 기준: #4 PR 설명, #6 설계 검토
+
+**이 프로젝트가 하는 일**
+- What: [한 문장]
+- Why: [한 문장]
+
+**전체 흐름**
+[Client] → [Filter] → [Handler/Router] → [Service] → [Repository] → [DB]
+
+**디렉토리 구조**
+[프로젝트의 실제 디렉토리 트리 — 이것이 L2 Discussion 목록이 됨]
+
+**📖 읽기 순서 가이드**
+> 이 프로젝트를 처음 읽는다면 아래 순서를 추천합니다.
+1. [첫 번째로 읽을 파일/패키지] — [이유]
+2. [두 번째] — [이유]
+3. ...
+
+**기술 선택**
+| 기술 | 선택 이유 |
+|------|-----------|
+
+**📝 용어 사전 (Glossary)**
+| 용어 | 설명 |
+|------|------|
+| [용어] | [주니어가 이해할 수 있는 한 줄 설명] |
+
+**⚙️ 환경/설정 개요**
+| 항목 | 값 / 설명 |
+|------|-----------|
+| [JDK/Node/Python 등] | [버전 및 필요 사항] |
+| [DB] | [종류 및 설정] |
+| [빌드 도구] | [Gradle/Maven/npm 등] |
+| [주요 설정 파일] | [application.yml 등 핵심 설정] |
+
+**📚 주니어 선수 지식** (해당 시)
+```
+
+### L2 · Modules (디렉토리)
+
+```markdown
+## 📦 [패키지 경로]
+
+> Section: [도메인] · Level: L2 · Modules
+> 📂 경로: `src/main/java/com/example/[패키지 경로]`
+> 리뷰 기준: #6 설계 검토, #8 복잡성, #9 네이밍
+
+**L1에서의 위치**: [전체 흐름 중 이 패키지가 담당하는 위치]
+
+**한 줄 요약**: [이 디렉토리의 책임]
+
+**포함된 파일**
+| 파일명 | 역할 |
+|--------|------|
+| [FileName.java] | [한 줄] |
+
+**🔄 파일 간 호출 흐름**
+```
+[파일A] → [파일B] → [파일C]
+  설명: [흐름을 한 줄로 요약]
+```
+
+**🧩 디자인 패턴 설명**
+| 패턴 | 적용 위치 | 주니어 설명 |
+|------|-----------|------------|
+| [패턴명] | [파일/클래스] | [왜 이 패턴을 썼는지, 안 쓰면 어떻게 되는지] |
+
+**의존 관계**: [이 패키지가 사용하는 다른 패키지]
+```
+
+### L3 · Code (소스 파일)
+
+**L3는 소스 파일 내의 함수/메서드 블록마다 개별 코드+설명 섹션을 생성합니다.**
+파일 전체를 하나의 코드 블록으로 퉁치지 않고, 함수 단위로 분리하여 각각 설명합니다.
+
+```markdown
+## 🔬 [패키지경로/FileName.java]
+
+> Section: [도메인] · Level: L3 · Code
+> 📂 경로: `src/main/java/com/example/[전체 경로]`
+> 리뷰 기준: [적용된 리뷰 기준]
+
+**📋 한 줄 요약**: [이 파일이 하는 일을 한 문장으로]
+
+---
+
+### 📍 이 코드의 위치
+
+**L1 아키텍처에서**: [전체 흐름 중 어디]
+**L2 패키지에서**: [어느 패키지의 어느 역할]
+
+---
+
+### 🔗 연관 파일 (See Also)
+
+| 파일 | 관계 | 설명 |
+|------|------|------|
+| [파일명] | [호출/구현/사용 등] | [어떤 관계인지 한 줄] |
+
+---
+
+### 0. 클래스 구조 (import, 필드, 어노테이션)
+
+\`\`\`[언어]
+[import문, 클래스 선언, 필드, 의존성 주입 등]
+\`\`\`
+
+**설명**
+
+| 줄 | 코드 | 의도 | 설명 | 리뷰 기준 |
+|----|------|------|------|----------|
+
+---
+
+### 1. [함수명/메서드명]
+
+\`\`\`[언어]
+[해당 함수의 코드]
+\`\`\`
+
+**설명**
+
+| 줄 | 코드 | 의도 | 설명 | 리뷰 기준 |
+|----|------|------|------|----------|
+| [줄번호] | `[코드]` | [왜 — 한 문장] | [쉬운 설명 1~2줄] | #[번호] [기준명] |
+
+---
+
+### 2. [함수명/메서드명]
+
+\`\`\`[언어]
+[해당 함수의 코드]
+\`\`\`
+
+**설명**
+
+| 줄 | 코드 | 의도 | 설명 | 리뷰 기준 |
+|----|------|------|------|----------|
+| [줄번호] | `[코드]` | [왜 — 한 문장] | [쉬운 설명 1~2줄] | #[번호] [기준명] |
+
+---
+
+(함수 개수만큼 반복)
+
+---
+
+### 💡 주니어 팁
+[이 파일/패턴을 처음 보는 사람이 알아야 할 것]
+
+### 🔒 보안·오류 처리 (해당 시)
+### ❌ 흔한 실수 (해당 시)
+```
+
+> **핵심**:
+> - `📍 이 코드의 위치` 절대 생략 금지
+> - L3 제목에 패키지 경로 포함 필수
+> - **함수/메서드 블록마다** 개별 코드+설명 섹션 생성 (파일 전체를 하나로 묶지 않음)
+> - 클래스 필드 선언, import, 어노테이션 등 함수 외부 코드는 "클래스 구조" 섹션으로 맨 앞에 배치
+> - L1에는 반드시 📖 읽기 순서, 📝 용어 사전, ⚙️ 환경/설정 개요 포함
+> - L2에는 반드시 🔄 파일 간 호출 흐름, 🧩 디자인 패턴 설명 포함
+> - L3에는 반드시 📋 한 줄 요약 (헤더 바로 뒤), 🔗 연관 파일 (📍 위치 뒤) 포함
+
+---
+
+## Discussion 제목 및 Label 규칙
+
+| 레벨 | 제목 형식 | Labels |
+|------|-----------|--------|
+| L1 | `🏗️ [프로젝트명] 전체 구조` | `L1`, `[프로젝트명]` |
+| L2 | `📦 [패키지 경로]` | `L2`, `[프로젝트명]` |
+| L3 | `🔬 [패키지경로/파일명]` | `L3`, `[프로젝트명]` |
+
+---
+
+## Phase 3: GitHub Discussion 적재
+
+**반드시 Python + `gh api graphql --input -` 방식을 사용합니다.**
+
+### Step 1 · 설정값 삽입 + Repository ID 조회
+
+```python
+import json, subprocess
+
+# config.json 값을 직접 삽입 (런타임 파일 읽기 대신)
+OWNER = "실제-owner"    # ← config.json의 discussion_repo_owner
+REPO = "실제-repo"      # ← config.json의 discussion_repo_name
+WEBHOOK_URL = ""        # ← config.json의 webhook_url (비어있으면 알림 스킵)
+
+# Repository ID 동적 조회
+repo_id_query = json.dumps({
+    "query": f'{{ repository(owner: "{OWNER}", name: "{REPO}") {{ id }} }}'
+})
+result = subprocess.run(
+    ["gh", "api", "graphql", "--input", "-"],
+    input=repo_id_query, capture_output=True, text=True
+)
+REPO_ID = json.loads(result.stdout)["data"]["repository"]["id"]
+```
+
+### Step 2 · General 카테고리 ID 조회
+
+```python
+# General 카테고리 ID를 동적으로 조회
+query = json.dumps({
+    "query": f'{{ repository(owner: "{OWNER}", name: "{REPO}") {{ discussionCategories(first: 20) {{ nodes {{ id name }} }} }} }}'
+})
+# "General" 카테고리의 ID를 추출
+```
+
+### Step 3 · Label 생성
+
+프로젝트명과 L1/L2/L3 label이 없으면 자동 생성합니다.
+
+```python
+# Label 생성 (없을 때만)
+create_label_query = r'mutation($repoId: ID!, $name: String!, $color: String!) { createLabel(input: { repositoryId: $repoId, name: $name, color: $color }) { label { id } } }'
+
+# Label 색상 규칙
+# L1: "d73a4a" (빨강)
+# L2: "0075ca" (파랑)
+# L3: "008672" (초록)
+# 프로젝트명: "e4e669" (노랑)
+```
+
+### Step 4 · Discussion 생성 + Label 부착
+
+```python
+import json, subprocess
+
+# 1. Discussion 생성 (General 카테고리)
+create_query = r'mutation($title: String!, $body: String!, $repoId: ID!, $catId: ID!) { createDiscussion(input: { repositoryId: $repoId, categoryId: $catId, title: $title, body: $body }) { discussion { id url } } }'
+
+# 2. Label 부착
+label_query = r'mutation($labelableId: ID!, $labelIds: [ID!]!) { addLabelsToLabelable(input: { labelableId: $labelableId, labelIds: $labelIds }) { labelable { labels(first: 5) { nodes { name } } } } }'
+```
+
+### 대상 저장소 정보
+
+대상 저장소는 `config.json`의 `discussion_repo_owner`와 `discussion_repo_name`에서 결정됩니다.
+Repository ID는 실행 시 GraphQL로 동적 조회합니다.
+
+> General 카테고리 ID와 Label ID는 실행 시 동적으로 조회합니다.
+
+### 적재 순서
+
+1. config.json에서 OWNER, REPO 읽기
+2. Repository ID 동적 조회
+3. General 카테고리 ID 조회
+4. Label 생성 (L1, L2, L3, 프로젝트명) — 없을 때만
+5. Label ID 조회
+6. L1 Discussion 생성 + Label 부착
+7. L2 Discussion 디렉토리 순으로 생성 + Label 부착
+8. L3 Discussion 디렉토리 순 > 파일명 순으로 생성 + Label 부착
+
+### 기존 Discussion 처리
+
+같은 제목의 Discussion이 이미 있으면:
+1. 기존 본문을 Comment로 보관 (이력 누적)
+2. Discussion 본문을 최신 내용으로 교체 (`updateDiscussion` mutation)
+
+---
+
+## Phase 3.5: GitHub Wiki 적재
+
+**Discussion 적재가 끝난 직후 동일한 L1/L2/L3 본문을 Wiki에도 push합니다.**
+Phase 0.4의 Wiki 사전 조건이 실패했으면 이 Phase 전체를 스킵합니다.
+
+### 핵심 원칙
+
+| 항목 | Discussion | Wiki |
+|------|------------|------|
+| 단위 | Discussion 1개 = 페이지 1개 | 마크다운 파일 1개 = 페이지 1개 |
+| 분류 | `L1`/`L2`/`L3` + 프로젝트명 Label | 파일명 prefix (`L1-` / `L2-` / `L3-`) |
+| 탐색 | 라벨 필터링 | `_Sidebar.md` 좌측 네비게이션 |
+| 버전 | 코멘트로 이력 백업 | git history 자동 누적 |
+
+### 페이지 명명 규칙
+
+Wiki는 **평면 파일 구조**이므로 디렉토리 경로는 하이픈으로 평탄화하여 prefix로 식별합니다.
+
+| 레벨 | 파일명 형식 | 예시 |
+|------|-------------|------|
+| L1 | `L1-<프로젝트명>.md` | `L1-board-playground.md` |
+| L2 | `L2-<패키지경로-하이픈>.md` | `L2-backend-src-auth.md` |
+| L3 | `L3-<패키지경로-하이픈>-<파일명>.md` | `L3-backend-src-auth-AuthService.md` |
+| 진입 | `Home.md` | (고정) |
+| 네비 | `_Sidebar.md` | (고정, 좌측 네비 자동 렌더링) |
+
+> 슬래시 `/`도 wiki에서 페이지 prefix로 동작하지만 URL 인코딩 케이스가 까다로워 하이픈을 권장합니다.
+> 파일명에 `<`, `>`, `:`, `"`, `\`, `|`, `?`, `*` 가 있으면 `_`로 치환합니다.
+
+### Step 1 · Wiki repo 클론
+
+`gh auth`가 발급한 토큰을 통해 인증된 URL로 클론합니다.
+
+```python
+import os, subprocess, tempfile, shutil
+
+OWNER = "실제-owner"     # ← config.json의 discussion_repo_owner 동일
+REPO = "실제-repo"        # ← config.json의 discussion_repo_name 동일
+
+# gh CLI가 git에 자격 증명을 위임하도록 helper 설정 (한 번만)
+subprocess.run(["gh", "auth", "setup-git"], check=True)
+
+wiki_dir = tempfile.mkdtemp(prefix="code-explainer-wiki-")
+wiki_url = f"https://github.com/{OWNER}/{REPO}.wiki.git"
+subprocess.run(["git", "clone", wiki_url, wiki_dir], check=True)
+```
+
+> 클론이 `Repository not found`로 실패하면 Phase 0.4에서 이미 걸러져 있어야 합니다.
+> 그래도 런타임에 실패하면 사용자에게 안내하고 Phase 3.5만 스킵합니다.
+
+### Step 2 · 페이지 파일 작성
+
+생성된 L1/L2/L3 본문을 각각 위 명명 규칙에 따라 `wiki_dir`에 저장합니다.
+
+```python
+def slugify_path(path: str) -> str:
+    """디렉토리 경로/파일명을 wiki 안전 파일명으로 변환"""
+    import re
+    s = path.replace("/", "-").replace("\\", "-").replace(".", "-")
+    s = re.sub(r'[<>:"|?*]', "_", s)
+    return s.strip("-")
+
+def write_page(filename: str, body: str):
+    path = os.path.join(wiki_dir, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(body)
+
+# L1 (1개)
+write_page(f"L1-{PROJECT_NAME}.md", l1_body)
+
+# L2 (디렉토리마다 1개)
+for pkg_path, body in l2_pages.items():
+    write_page(f"L2-{slugify_path(pkg_path)}.md", body)
+
+# L3 (소스 파일마다 1개)
+for src_path, body in l3_pages.items():
+    write_page(f"L3-{slugify_path(src_path)}.md", body)
+```
+
+### Step 3 · Home.md & _Sidebar.md 생성
+
+평면 구조에서도 탐색 가능하도록 진입 페이지와 좌측 네비를 동시에 만듭니다.
+
+```python
+# Home.md — 진입 페이지
+home_body = f"""# {PROJECT_NAME}
+
+> code-explainer 자동 생성 학습 문서. 좌측 사이드바에서 L1/L2/L3을 탐색하세요.
+
+## 🏗️ L1 · Architecture
+- [[L1-{PROJECT_NAME}]]
+
+## 📦 L2 · Modules
+"""
+for pkg_path in sorted(l2_pages.keys()):
+    home_body += f"- [[L2-{slugify_path(pkg_path)}]] — `{pkg_path}`\n"
+
+home_body += "\n## 🔬 L3 · Code\n"
+for src_path in sorted(l3_pages.keys()):
+    home_body += f"- [[L3-{slugify_path(src_path)}]] — `{src_path}`\n"
+
+write_page("Home.md", home_body)
+
+# _Sidebar.md — 좌측 네비 (모든 페이지에 자동 표시)
+sidebar_body = f"""**🏗️ Architecture**
+- [[L1-{PROJECT_NAME}]]
+
+**📦 Modules (L2)**
+"""
+for pkg_path in sorted(l2_pages.keys()):
+    sidebar_body += f"- [[L2-{slugify_path(pkg_path)}|{pkg_path}]]\n"
+
+sidebar_body += "\n**🔬 Code (L3)**\n"
+for src_path in sorted(l3_pages.keys()):
+    label = src_path.split("/")[-1]  # 파일명만 표시
+    sidebar_body += f"- [[L3-{slugify_path(src_path)}|{label}]]\n"
+
+write_page("_Sidebar.md", sidebar_body)
+```
+
+> `[[페이지명]]` 또는 `[[표시텍스트|페이지명]]` 형식이 GitHub Wiki의 internal link 문법입니다.
+
+### Step 4 · 커밋 & 푸시
+
+```python
+subprocess.run(["git", "-C", wiki_dir, "add", "-A"], check=True)
+
+# 변경 사항이 있을 때만 커밋
+status = subprocess.run(
+    ["git", "-C", wiki_dir, "status", "--porcelain"],
+    capture_output=True, text=True, check=True
+).stdout.strip()
+
+if status:
+    from datetime import datetime
+    msg = f"code-explainer: update {PROJECT_NAME} ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})"
+    subprocess.run(["git", "-C", wiki_dir, "commit", "-m", msg], check=True)
+    subprocess.run(["git", "-C", wiki_dir, "push"], check=True)
+    print(f"✅ Wiki 업데이트 완료: https://github.com/{OWNER}/{REPO}/wiki")
+else:
+    print("ℹ️ Wiki 변경 사항 없음 — 커밋 생략")
+
+# 임시 디렉토리 정리
+shutil.rmtree(wiki_dir, ignore_errors=True)
+```
+
+### 기존 Wiki 페이지 처리
+
+Discussion과 달리 별도의 "이전 본문 백업" 절차가 **필요 없습니다** — wiki repo는 git이므로 새 커밋이 자동으로 history에 누적되며, GitHub UI의 "Revisions" 탭에서 모든 과거 버전을 확인할 수 있습니다.
+
+### 적재 순서
+
+1. `gh auth setup-git` 1회 실행 (idempotent)
+2. wiki repo를 임시 디렉토리에 clone
+3. L1 / L2 / L3 페이지 파일 작성 (L1 → L2 → L3 순)
+4. `Home.md`, `_Sidebar.md` 생성
+5. `git add -A` → 변경 있을 때만 `commit` + `push`
+6. 임시 디렉토리 삭제
+
+### 실패 처리
+
+- 인증 실패 (403) → `gh auth refresh -s repo` 안내 후 Wiki만 스킵
+- clone 실패 (404) → Phase 0.4 안내 재출력 후 Wiki만 스킵
+- push 실패 (non-fast-forward) → `git pull --rebase` 후 재푸시 1회 시도, 그래도 실패하면 Wiki만 스킵
+
+> **Discussion 적재는 절대 영향받지 않습니다.** Wiki 실패는 항상 soft-fail.
+
+---
+
+## Phase 4: PR 업데이트
+
+PR이 있는 경우 Discussion 링크와 Wiki Home 링크를 PR 코멘트로 추가합니다.
+Wiki Phase가 스킵됐다면 Discussion 링크만 포함합니다.
+
+---
+
+## Phase 5: Google Chat 알림
+
+config.json의 `webhook_url` 값을 사용합니다. **값이 비어있으면 이 Phase를 스킵합니다.**
+
+```python
+WEBHOOK_URL = ""  # ← config.json의 webhook_url
+
+if WEBHOOK_URL:
+    # Google Chat 알림 전송
+    import urllib.request
+    wiki_line = f"\n📚 Wiki: https://github.com/{OWNER}/{REPO}/wiki" if WIKI_PUSHED else "\n📚 Wiki: (스킵됨)"
+    message = json.dumps({
+        "text": f"✅ *code-explainer 완료*\n\n📌 도메인: [도메인명]\n📂 분석 대상: [경로]\n\n*생성된 문서:*\n• 🏗️ L1: 1개\n• 📦 L2: N개 (디렉토리)\n• 🔬 L3: N개 (소스 파일)\n\n💬 Discussions: https://github.com/{OWNER}/{REPO}/discussions{wiki_line}\nLabels: L1, L2, L3, [프로젝트명]"
+    })
+    req = urllib.request.Request(WEBHOOK_URL, data=message.encode(), headers={"Content-Type": "application/json"})
+    urllib.request.urlopen(req)
+else:
+    print("ℹ️ webhook_url이 비어있어 Google Chat 알림을 스킵합니다.")
+```
+
+---
+
+## 버전 관리
+
+Discussion 본문의 `> 리뷰 기준:` 라인 아래에 버전 정보를 표시합니다.
+
+```
+> 리뷰 기준: #6 설계 검토, #9 네이밍
+> 📌 v2 · 2026-05-08 11:32:04
+```
+
+- 신규 생성: `v1`
+- 업데이트: 기존 버전에서 +1 (v1→v2→v3...)
+- 타임스탬프: `YYYY-MM-DD HH:MM:SS` (초 단위)
+
+---
+
+## 자동 실행 규칙 (중간 확인 없음)
+
+코드 분석 요청("분석해줘", "설명해줘", Git URL, 폴더/파일 경로 제공)을 받으면 **확인 없이 끝까지 자동 실행**합니다.
+
+```
+자동 실행 파이프라인 (중간 확인 없음):
+  1. Phase 0: 설정 확인 (config.json + gh 인증 + Discussion 활성화 + Wiki 초기화)
+  2. 코드 분석 + L1/L2/L3 문서 생성 + 업로드 스크립트 생성
+  3. 업로드 스크립트 실행 → Discussion 생성/업데이트 + Label 부착
+  3.5. Wiki 적재 → wiki repo clone + 페이지 파일 작성 + Home/Sidebar 생성 + push
+       (Wiki 사전 조건 실패 시 이 단계만 스킵)
+  4. PR 코멘트 업데이트 (PR이 있을 때만)
+  5. Google Chat 알림 전송 (webhook_url이 비어있으면 스킵)
+  6. 결과 요약 출력
+```
+
+> ⚠️ "실행할까요?", "업로드할까요?" 같은 확인을 **절대 하지 않습니다**.
+> 분석 요청을 받은 시점에서 Discussion + Wiki 업로드 + Google Chat 알림까지 한 번에 완료합니다.
+
+---
+
+## 실행 체크리스트
+
+- [ ] Phase 0: 설정 확인 (config.json + gh 인증 + Discussion 활성화 + Wiki 초기화 체크)
+- [ ] Step 1~2: 코드 스캔 + 읽기
+- [ ] Step 3~5: L1 → L2 (디렉토리별) → L3 (파일별) 문서 생성
+- [ ] Phase 3: Label 생성 + Discussion 적재 + Label 부착 완료
+- [ ] Phase 3.5: Wiki repo clone + 페이지 파일 작성 + Home/Sidebar 생성 + push (사전 조건 실패 시 스킵)
+- [ ] Phase 4: PR 코멘트 (해당 시) — Discussion + Wiki Home 링크 포함
+- [ ] Phase 5: Google Chat 알림 — webhook_url 비어있으면 스킵
+
+**결과**: 생성된 Discussion URL 전체 목록 + Wiki Home URL + Google Chat 전송 결과
+
+---
+
+## Tips
+
+- **디렉토리 = Discussion = Wiki 페이지**: 프로젝트 탐색하듯 Discussion 또는 Wiki를 탐색할 수 있어야 합니다.
+- **L3는 예외 없이 전부**: DTO든 Router든 모든 파일에 대해 생성합니다. 주니어는 어떤 파일이 "단순"한지 모릅니다.
+- **레벨 지정 가능**: "L3만 뽑아줘", "account 모듈만 설명해줘" 처럼 범위를 좁힐 수 있습니다.
+- **증분 모드**: 파일 하나만 주면 해당 L3만 생성/업데이트하고 기존 L1·L2는 재사용합니다. Wiki도 동일 파일만 갱신.
+- **수동 세팅 최소**: Discussion은 General 카테고리 + Label 방식이라 활성화만 되어 있으면 바로 작동. Wiki는 첫 페이지 1개만 UI에서 만들면 그 이후로는 자동.
+- **Discussion vs Wiki 어느 쪽이 더 좋나?**: Discussion은 라벨 검색·코멘트 토론에 강점, Wiki는 사이드바 네비·git 이력 추적에 강점. 둘 다 올려두면 사용자가 선호하는 쪽에서 학습 가능.

--- a/code-explainer-plugin/skills/code-explainer/SKILL.md
+++ b/code-explainer-plugin/skills/code-explainer/SKILL.md
@@ -535,6 +535,8 @@ subprocess.run(["git", "clone", wiki_url, wiki_dir], check=True)
 
 생성된 L1/L2/L3 본문을 각각 위 명명 규칙에 따라 `wiki_dir`에 저장합니다.
 
+> **헤더 정책 (중복 H1 회피)**: 본문 원본이 `## 🏗️ ...` 같은 H2로 시작한다면 그 줄을 제거하고 wiki 페이지 첫 줄에 `# {title}` H1을 *단 한 번만* 넣습니다. 두 헤더가 모두 살아 있으면 GitHub Wiki UI에서 같은 제목이 두 번 노출됩니다.
+
 ```python
 def slugify_path(path: str) -> str:
     """디렉토리 경로/파일명을 wiki 안전 파일명으로 변환"""
@@ -543,65 +545,76 @@ def slugify_path(path: str) -> str:
     s = re.sub(r'[<>:"|?*]', "_", s)
     return s.strip("-")
 
-def write_page(filename: str, body: str):
+def write_page(filename: str, title: str, body: str):
+    # 원본 첫 줄이 `## ...` H2면 제거 — H1으로 통일
+    lines = body.splitlines()
+    if lines and lines[0].startswith("## "):
+        body = "\n".join(lines[1:]).lstrip("\n")
+    full = f"# {title}\n\n{body}"
     path = os.path.join(wiki_dir, filename)
     with open(path, "w", encoding="utf-8") as f:
-        f.write(body)
+        f.write(full)
 
 # L1 (1개)
-write_page(f"L1-{PROJECT_NAME}.md", l1_body)
+write_page(f"L1-{PROJECT_NAME}.md", l1_title, l1_body)
 
 # L2 (디렉토리마다 1개)
 for pkg_path, body in l2_pages.items():
-    write_page(f"L2-{slugify_path(pkg_path)}.md", body)
+    write_page(f"L2-{slugify_path(pkg_path)}.md", f"📦 {pkg_path}", body)
 
 # L3 (소스 파일마다 1개)
 for src_path, body in l3_pages.items():
-    write_page(f"L3-{slugify_path(src_path)}.md", body)
+    write_page(f"L3-{slugify_path(src_path)}.md", f"🔬 {src_path}", body)
 ```
 
 ### Step 3 · Home.md & _Sidebar.md 생성
 
 평면 구조에서도 탐색 가능하도록 진입 페이지와 좌측 네비를 동시에 만듭니다.
 
+> **링크 문법 정책 (BLOCK)**: Gollum의 `[[Page|Display]]` 문법은 GitHub Wiki 사이드바에서 종종 렌더에 실패합니다 (히스토리상 사용자 보고됨). 따라서 **표준 markdown link `[Display](Page)` 형식을 사용**합니다. `Page` 부분은 wiki 파일명 (확장자 없음, 같은 wiki 내 상대 경로).
+
 ```python
-# Home.md — 진입 페이지
-home_body = f"""# {PROJECT_NAME}
+def link(display: str, page: str) -> str:
+    """표준 markdown wiki link — Gollum [[X|Y]] 대신 사용 (BLOCK)."""
+    return f"[{display}]({page})"
 
-> code-explainer 자동 생성 학습 문서. 좌측 사이드바에서 L1/L2/L3을 탐색하세요.
-
-## 🏗️ L1 · Architecture
-- [[L1-{PROJECT_NAME}]]
-
-## 📦 L2 · Modules
-"""
+# Home.md — 진입 페이지 (직접 작성 — write_page 안 거침: 자체 H1 제어)
+home_lines = [
+    f"# {PROJECT_NAME}\n\n",
+    "> code-explainer 자동 생성 학습 문서. 좌측 사이드바 또는 아래 목록에서 L1/L2/L3을 탐색하세요.\n\n",
+    "## 🏗️ L1 · Architecture\n\n",
+    f"- {link(l1_title.replace('🏗️ ', ''), f'L1-{PROJECT_NAME}')}\n",
+    "\n## 📦 L2 · Modules\n\n",
+]
 for pkg_path in sorted(l2_pages.keys()):
-    home_body += f"- [[L2-{slugify_path(pkg_path)}]] — `{pkg_path}`\n"
+    home_lines.append(f"- {link(pkg_path, f'L2-{slugify_path(pkg_path)}')}\n")
 
-home_body += "\n## 🔬 L3 · Code\n"
+home_lines.append("\n## 🔬 L3 · Code\n\n")
 for src_path in sorted(l3_pages.keys()):
-    home_body += f"- [[L3-{slugify_path(src_path)}]] — `{src_path}`\n"
+    home_lines.append(f"- {link(src_path, f'L3-{slugify_path(src_path)}')}\n")
 
-write_page("Home.md", home_body)
+with open(os.path.join(wiki_dir, "Home.md"), "w", encoding="utf-8") as f:
+    f.write("".join(home_lines))
 
 # _Sidebar.md — 좌측 네비 (모든 페이지에 자동 표시)
-sidebar_body = f"""**🏗️ Architecture**
-- [[L1-{PROJECT_NAME}]]
-
-**📦 Modules (L2)**
-"""
+sidebar_lines = [
+    "**🏗️ Architecture**\n\n",
+    f"- {link(l1_title.replace('🏗️ ', ''), f'L1-{PROJECT_NAME}')}\n",
+    "\n**📦 Modules (L2)**\n\n",
+]
 for pkg_path in sorted(l2_pages.keys()):
-    sidebar_body += f"- [[L2-{slugify_path(pkg_path)}|{pkg_path}]]\n"
+    sidebar_lines.append(f"- {link(pkg_path, f'L2-{slugify_path(pkg_path)}')}\n")
 
-sidebar_body += "\n**🔬 Code (L3)**\n"
+sidebar_lines.append("\n**🔬 Code (L3)**\n\n")
 for src_path in sorted(l3_pages.keys()):
     label = src_path.split("/")[-1]  # 파일명만 표시
-    sidebar_body += f"- [[L3-{slugify_path(src_path)}|{label}]]\n"
+    sidebar_lines.append(f"- {link(label, f'L3-{slugify_path(src_path)}')}\n")
 
-write_page("_Sidebar.md", sidebar_body)
+with open(os.path.join(wiki_dir, "_Sidebar.md"), "w", encoding="utf-8") as f:
+    f.write("".join(sidebar_lines))
 ```
 
-> `[[페이지명]]` 또는 `[[표시텍스트|페이지명]]` 형식이 GitHub Wiki의 internal link 문법입니다.
+> **링크 검증**: push 직후 `curl -sI {wiki_base}/L1-{PROJECT_NAME}` 등으로 직접 URL이 200을 반환하는지 확인. 페이지 본문은 정상이지만 사이드바 링크가 깨지는 케이스(Gollum 문법 실패)를 미리 감지.
 
 ### Step 4 · 커밋 & 푸시
 

--- a/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.acceptance.md
+++ b/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.acceptance.md
@@ -1,0 +1,97 @@
+---
+doc_type: feature-acceptance
+version: v0.1 (Draft)
+status: Draft
+author: woosung.ahn@bespinglobal.com
+date: 2026-05-20
+gate: feature
+related:
+  R-ID: []
+  F-ID: []
+  supersedes: null
+---
+
+# code-explainer 플러그인 도입 — Acceptance Criteria
+
+## 변경 이력
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v0.1 | 2026-05-20 | woosung.ahn | 초안 (scaffold-doc.sh 생성) |
+
+## 1. 인수 기준 (Given/When/Then)
+
+### AC-1. 플러그인 디렉토리 존재
+
+- **Given** main 브랜치에서 `code-explainer-plugin/` 디렉토리가 없는 상태
+- **When** 본 PR이 머지됨
+- **Then** `code-explainer-plugin/{SKILL.md(via skills/code-explainer/), config.json, README.md, .claude-plugin/plugin.json, LICENSE}` 5개 파일이 존재
+
+### AC-2. SKILL.md에 Wiki Phase 포함
+
+- **Given** `code-explainer-plugin/skills/code-explainer/SKILL.md` 존재
+- **When** 파일을 grep
+- **Then** `Phase 3.5: GitHub Wiki 적재` 헤더와 `4. Wiki 활성화 + 초기화 확인` 헤더가 둘 다 존재
+
+### AC-3. config.json이 board-playground로 설정
+
+- **Given** `code-explainer-plugin/config.json` 존재
+- **When** `jq` 파싱
+- **Then** `discussion_repo_owner == "sungjunchoi-bespin"` AND `discussion_repo_name == "board-playground"`
+
+### AC-4. frontend 적재 — Discussion
+
+- **Given** Wiki/Discussion 사전 조건 충족 + `/code-explainer frontend/` 실행 완료
+- **When** GitHub Discussions 페이지 확인
+- **Then** L1 1개 + L2 ≥ 8개 + L3 = 28개 = 총 **≥ 37개** Discussion이 `label:board-playground` 필터로 보임
+
+### AC-5. frontend 적재 — Wiki
+
+- **Given** AC-4와 같은 실행 완료
+- **When** `https://github.com/sungjunchoi-bespin/board-playground/wiki` 확인
+- **Then** `Home`, `_Sidebar`, `L1-board-playground`, `L2-frontend-src-*` (≥ 8개), `L3-frontend-src-*-*` (= 28개) 페이지가 존재
+
+### AC-6. 기존 빌드 무영향
+
+- **Given** main + 본 PR diff 적용 상태
+- **When** `cd frontend && pnpm tsc --noEmit && pnpm build` 실행
+- **Then** exit code 0, 새로운 에러/경고 0건
+
+### AC-7. feature 산출 문서 schema-validate
+
+- **Given** `docs/features/feat-code-explainer-plugin/*.md` 6개 파일
+- **When** `.claude/scripts/validate-doc.sh` 각각 실행
+- **Then** 6/6 PASS
+
+## 2. Definition of Done (D-06)
+
+### 1단 — AI 게이트 (PR 생성 전)
+
+- [ ] AC-1 ~ AC-7 모두 PASS
+- [ ] `docs/features/feat-code-explainer-plugin/*.md` 6개 schema-validate PASS
+- [ ] PR 본문 Test Plan 4블록 포함 (`docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.ai-qa.md` 또는 PR body에 직접 기재)
+- [ ] 6번째 축(3 profile 부팅) — **N/A 사유 명시** (소스/의존성/profile 자산 무변경)
+- [ ] 5번째 축(stylesheet 적용) — **N/A 사유 명시** (`ui_changed=false`, frontend/ 디렉토리 미접촉)
+
+### 2단 — 휴먼 게이트 (머지 전)
+
+- [ ] `tested` 라벨 부착
+- [ ] Approve ≥ 1
+- [ ] CI green (existing build/test workflow)
+- [ ] Discussion 인덱스 URL + Wiki Home URL이 PR 본문에 첨부됨
+
+## 3. 비기능 인수
+
+| 축 | 기준 | 측정 |
+|---|---|---|
+| 성능 | 플러그인이 board-playground 런타임에 영향 0 | 빌드 시간 변화 ≤ 1% (외부 디렉토리이므로 자동) |
+| 보안 | 시크릿/토큰 커밋 없음 | `code-explainer-plugin/config.json` `webhook_url=""` 비어있음 확인 |
+| 호환성 | 기존 frontend/backend/CI 빌드 무회귀 | AC-6으로 검증 |
+| 운영 | `git revert` 1회로 100% 롤백 가능 | Rollback 시나리오로 검증 |
+
+## 4. 회귀 인수
+
+- [ ] `pnpm tsc --noEmit` (frontend) — 본 PR 이전 대비 에러 변화 0
+- [ ] `pnpm build` (frontend) — 본 PR 이전 대비 출력 변화 0
+- [ ] `./gradlew build` (backend) — 본 PR 이전 대비 결과 변화 0 (`backend/` 디렉토리 미접촉)
+- [ ] 기존 docs/planning 문서 무변경 — `git diff main -- docs/planning/` 결과 0줄

--- a/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.brief.md
+++ b/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.brief.md
@@ -1,0 +1,76 @@
+---
+doc_type: feature-brief
+version: v0.1 (Draft)
+status: Draft
+author: woosung.ahn@bespinglobal.com
+date: 2026-05-20
+gate: feature
+related:
+  R-ID: []
+  F-ID: []
+  supersedes: null
+---
+
+# code-explainer 플러그인 도입 — Feature Brief
+
+## 변경 이력
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v0.1 | 2026-05-20 | woosung.ahn | 초안 (scaffold-doc.sh 생성) |
+
+## 1. 한 줄 의도
+
+board-playground 신규 합류자가 React/Spring 코드를 빠르게 학습할 수 있도록 **L1/L2/L3 3단계 학습 문서**를 자동 생성하여 GitHub Discussion + Wiki에 동시 적재하는 외부 플러그인을 도입한다.
+
+## 2. 사용자 가치
+
+| 페르소나 | 현재 | 가치 |
+|---|---|---|
+| 신규 합류자 | `04-srs` / `06-architecture`는 의도/요구 중심이라 "어떤 파일의 어떤 함수가 무엇을 하는지" 찾기 어려움 | 파일 단위 학습 문서가 Discussion + Wiki에 자동 적재되어 위키 사이드바·라벨 필터로 탐색 가능 |
+| 코드리뷰어 | PR 본문만으로 변경 맥락 파악 | 변경 파일에 해당하는 L3 페이지로 즉시 이동 가능 |
+| 운영자 | 별도 문서 유지 부담 | 코드 변경 시 플러그인 재실행으로 문서 자동 갱신 (Wiki는 git history로 버전 누적, Discussion은 코멘트로 백업) |
+
+## 3. 현재 상태 → 변경 후 상태
+
+| 측면 | 현재 | 변경 후 |
+| --- | --- | --- |
+| 학습 진입점 | `README.md` + `docs/planning/01-project-brief` | + `https://github.com/sungjunchoi-bespin/board-playground/wiki` (Home + Sidebar 자동 생성) |
+| 코드 단위 설명 | 없음 (코드 직접 읽기) | L3 페이지 28개 (frontend/src TS/TSX) |
+| 모듈 단위 설명 | `06-architecture` HLD 일부 | L2 페이지 ~8개 (디렉토리별 책임·파일·디자인 패턴) |
+| 전체 흐름 | `06-architecture` | L1 1개 (읽기 순서 가이드 + 용어 사전 + 환경/설정 개요) |
+| sink | 없음 | Discussion (라벨 분류) + Wiki (사이드바 네비) 동시 |
+
+## 4. 모드 자동 감지 결과
+
+- 입력 자연어 / 라벨 분석:
+  - `type:bug` 라벨/에러 키워드: **없음**
+  - UI/token/시각 키워드: **없음**
+  - 기존 동작 변경 / breaking 키워드: **없음**
+- ADR-0032 §2.1 — 부정 시그널 0건 → **mode=add** 자동 결정
+- 자동 결정이며 사용자 질문 없이 진행 (ADR-0032 §2.2)
+
+## 5. 영향 범위
+
+| 영역 | 변경 |
+|---|---|
+| `code-explainer-plugin/` (신규) | 플러그인 본체 5파일 추가 |
+| `code-explainer-plugin/skills/code-explainer/SKILL.md` | Phase 0.4 (Wiki 사전 조건) + Phase 3.5 (Wiki 적재) 추가, 파이프라인/체크리스트/Tips 갱신 |
+| `code-explainer-plugin/README.md` | Discussion + Wiki 동시 적재 명시, 구조 표 갱신 |
+| `code-explainer-plugin/config.json` | `discussion_repo_owner=sungjunchoi-bespin`, `discussion_repo_name=board-playground` 채움 |
+| 기존 `frontend/`, `backend/`, `docs/planning/` 등 | **변경 없음** (플러그인은 외부 도구, 빌드 의존 없음) |
+| 외부 영향 | GitHub Discussions에 ~37 항목 신규 생성, Wiki에 ~37 페이지 + Home/_Sidebar push |
+
+## 6. 비목표
+
+- backend(108 파일) 적재 — 후속 이슈로 분리
+- 다국어 출력 (한국어만)
+- 자동 재실행 스케줄러 (수동 `/code-explainer` 실행)
+- Google Chat 알림 (`webhook_url` 빈 값으로 스킵)
+- 플러그인의 CI 통합 (이번 PR은 도입만)
+
+## 7. Open Questions
+
+- (해소됨) Wiki 적재 방식 → wiki repo clone + push 결정
+- (해소됨) 같은 저장소 vs 별도 저장소 → Discussion과 동일 저장소
+- (해소됨) 항상 켜기 vs 토글 → 항상 켜기, 사전 조건 실패 시 Wiki만 soft-skip

--- a/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.contract.md
+++ b/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.contract.md
@@ -1,0 +1,82 @@
+---
+doc_type: feature-contract
+version: v0.1 (Draft)
+status: Draft
+author: woosung.ahn@bespinglobal.com
+date: 2026-05-20
+gate: feature
+related:
+  R-ID: []
+  F-ID: []
+  supersedes: null
+---
+
+# code-explainer 플러그인 도입 — Change Contract
+
+## 변경 이력
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v0.1 | 2026-05-20 | woosung.ahn | 초안 (scaffold-doc.sh 생성) |
+
+## 0. 참조 정본 ID (Referenced-IDs)
+
+| 종류 | 정본 위치 | 영향 ID |
+| --- | --- | --- |
+| Requirement | (none) | — 본 변경은 학습 보조 도구 도입으로 기능 요구사항(R-/F-)을 새로 추가하거나 변경하지 않음 |
+| ADR | `docs/planning/adr/` | (none) — 외부 플러그인 추가는 board-playground 빌드/런타임 의존을 변경하지 않으므로 ADR 불요 |
+| 코딩 컨벤션 | `docs/planning/11-coding-conventions/11-coding-conventions.md` | (none) — 본 PR diff는 `code-explainer-plugin/` 디렉토리만 추가, 기존 컨벤션 적용 대상이 아님 |
+| 스카폴딩 | `docs/planning/12-scaffolding/{java,typescript}.md` | (none) — 빌드 명령 영향 없음 |
+| 시나리오/시험 | `docs/planning/13-test-design/13-test-design.md` | (none) — 본 플러그인은 board-playground 빌드/테스트 파이프라인 외부에서 실행되며, 별도 테스트 catalog 갱신 불요 |
+
+## 1. 변경 의도
+
+`code-explainer-plugin/` 디렉토리를 board-playground 루트에 신규 추가하여, Claude Code에서 `/code-explainer <path>` 호출 시 frontend(또는 추후 backend)의 학습 문서를 자동 생성하고 GitHub Discussion + Wiki 두 sink에 동시 적재한다.
+
+## 2. Before / After
+
+| 항목 | Before | After |
+| --- | --- | --- |
+| 플러그인 디렉토리 | 없음 | `code-explainer-plugin/` (5 파일 + .claude-plugin 메타) |
+| Wiki sink | 미사용 | `Home.md`, `_Sidebar.md`, `L1-<프로젝트>.md`, `L2-<dir>.md`, `L3-<dir>-<file>.md` 자동 push |
+| Discussion sink | 미사용 | General 카테고리에 L1/L2/L3 + 프로젝트명 Label로 분류 적재 |
+| 학습 진입점 (Wiki) | 비어있음 | `https://github.com/sungjunchoi-bespin/board-playground/wiki` Home에서 L1 → L2 → L3 탐색 가능 |
+| frontend 코드 | 변경 없음 | 변경 없음 (플러그인은 외부 도구) |
+| backend 코드 | 변경 없음 | 변경 없음 |
+| `package.json` / `pom.xml` / `build.gradle` | 변경 없음 | 변경 없음 (빌드 의존 추가 없음) |
+| 3 profile boot (dev/stg/prod) | 영향 없음 | 영향 없음 (LOCAL.md / 12-scaffolding 갱신 불요) |
+
+## 3. 호출자·의존자 (Call Sites)
+
+| 위치 | 영향 | 조치 |
+| --- | --- | --- |
+| `frontend/` 빌드 (`pnpm build`) | 없음 | 검증 — `tsc` / `vite build`가 `code-explainer-plugin/`을 스캔하지 않음 (frontend/tsconfig.json 범위 외) |
+| `backend/` 빌드 (`./gradlew build`) | 없음 | 검증 — `code-explainer-plugin/`은 `backend/` 외부 |
+| CI 워크플로 (`.github/workflows/`) | 없음 | 영향 없음 (CI는 빌드만 수행, plugin은 로컬 실행) |
+| `.gitignore` | 변경 없음 | plugin 디렉토리는 git tracked |
+| GitHub Discussions / Wiki | 신규 콘텐츠 적재 | 사용자 트리거(`/code-explainer`)로만 적재 |
+
+## 4. Backward Compatibility
+
+- **완전 호환**. 본 변경은 기존 코드/빌드/실행/CI 경로를 일절 건드리지 않는다.
+- 플러그인 미사용자(`/code-explainer`를 호출하지 않는 사용자)는 디렉토리 1개의 존재 외 어떤 영향도 받지 않는다.
+- Discussions/Wiki에 신규 페이지가 생기지만, 기존 페이지(없음)를 덮어쓰지 않는다.
+- breaking change 없음 → ADR 불요 (mode=add 정책)
+
+## 5. Rollback 전략
+
+| 시나리오 | 조치 |
+|---|---|
+| 플러그인 도입 자체 롤백 | `git revert` 1회 — `code-explainer-plugin/` 디렉토리 통째 제거. 빌드/런타임 영향 0. |
+| Wiki 페이지만 제거 | wiki repo를 클론해서 해당 파일 삭제 후 push. Discussion은 별도. |
+| Discussion 항목만 제거 | GitHub UI에서 일괄 삭제, 또는 GraphQL mutation으로 batch delete. |
+| 둘 다 제거 | 위 두 단계 병행. plugin 코드 자체는 유지 가능 (idempotent 재실행 시 다시 생성). |
+
+## 6. 비목표
+
+- backend 적재 (별도 이슈)
+- 영문/다국어 문서 출력
+- 자동 스케줄링 (cron, GitHub Actions 등)
+- Google Chat 알림 (`webhook_url`을 채우는 후속 작업)
+- 플러그인 자체의 단위 테스트 추가 (외부 도구이므로 board-playground 테스트 catalog 외)
+- 02-test-catalog 또는 13-test-design 갱신 (테스트 영향 없음)

--- a/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.eng-review.md
+++ b/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.eng-review.md
@@ -1,0 +1,87 @@
+---
+doc_type: feature-eng-review
+version: v0.1 (Draft)
+status: Draft
+author: woosung.ahn@bespinglobal.com
+date: 2026-05-20
+gate: feature
+related:
+  R-ID: []
+  F-ID: []
+  supersedes: null
+---
+
+# code-explainer 플러그인 도입 — Engineering Review
+
+## 변경 이력
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v0.1 | 2026-05-20 | woosung.ahn | 초안 (scaffold-doc.sh 생성) |
+
+## 0. Verdict
+
+**PASS** — 본 변경은 board-playground 빌드/런타임/CI에 영향이 0이며, 외부 도구 디렉토리 추가에 한정된다. Backward compatibility 100%. Rollback은 `git revert` 1회. 위험도 매우 낮음.
+
+- reviewer: woosung.ahn@bespinglobal.com
+- review_at: 2026-05-20
+
+## 1. Contract 검토
+
+| 항목 | 검토 결과 |
+|---|---|
+| §0 Referenced-IDs | OK — R-/F-/ADR/컨벤션/스카폴딩/시험 6개 항목 모두 `(none)` 사유 명시 |
+| §1 변경 의도 | OK — 1단락 명확 |
+| §2 Before/After | OK — 빌드/3 profile 부팅 무영향 명시 |
+| §3 Call Sites | OK — frontend/backend 빌드 미접촉, .gitignore 무영향 |
+| §4 Backward Compatibility | OK — "완전 호환" 선언 + 사유 |
+| §5 Rollback | OK — 4가지 시나리오 명시 |
+
+## 2. Plan 검토
+
+| 항목 | 검토 결과 |
+|---|---|
+| §1 커밋 DAG | OK — C1→C2→C3→C4 4단계, 의존 관계 명확 |
+| §3 테스트 매핑 | OK — 코드 추가 없음으로 schema-validate + manual end-to-end로 갈음. 사유 적절 |
+| §4 빌드·실행 검증 | OK — 5단계 명령 명시. **3 profile 부팅 N/A** 사유(소스/의존성/profile 자산 무변경) 적절 |
+| §5 점진 합의 | OK — 사전 결정 4건 모두 해소됨 |
+
+## 3. UX 검토
+
+해당 없음 — 본 변경은 frontend UI에 변화를 일으키지 않는다. Wiki/Discussion 페이지의 시각 디자인은 GitHub 플랫폼 표준을 따른다.
+
+## 4. 6단계 폴더링 충족
+
+| 단계 | 충족 여부 |
+|---|---|
+| ① 책임 1개 폴더 | OK — `code-explainer-plugin/` (외부 도구) + `docs/features/feat-code-explainer-plugin/` (산출 묶음) |
+| ② 명명 규약 | OK — `feat-<slug>/feat-<slug>.{brief,contract,plan,eng-review,acceptance,risk}.md` |
+| ③ 최소 분량 | OK — 각 산출 문서 ≤ 200줄 수준 |
+| ④ 정본 위치 | OK — `docs/features/<slug>/` (manifest §3.2 정합) |
+| ⑤ INDEX.md | N/A — feature 폴더는 INDEX.md 강제 대상 아님 |
+| ⑥ schema mapping | OK — feature-{brief,contract,plan,eng-review,acceptance,risk} 6개 매핑 |
+
+## 5. frontmatter / Manifest 검증
+
+```bash
+for f in docs/features/feat-code-explainer-plugin/*.md; do
+  bash .claude/scripts/validate-doc.sh "$f"
+done
+```
+
+검증 명령은 §1 §2 PASS 직후 실행하며, 결과는 P10(`/qa-test --ai`) 직전 PR 본문 첨부 시 다시 확인한다.
+
+## 6. 발견 사항 (3축 OX)
+
+| Q | 답 | 처리 |
+| --- | --- | --- |
+| Contract §0 Referenced-IDs 5행 모두 채워졌는가? | O | — |
+| Before/After가 모든 영향 축(빌드/런타임/CI/3 profile)을 다루는가? | O | — |
+| Rollback이 단일 명령으로 실행 가능한가? | O | `git revert` 1회 |
+| Plan 커밋이 회귀 위험을 다루는가? | O | 회귀 위험 0건 (코드 무변경) |
+| 단위 테스트 부재가 정당화되는가? | O | 외부 도구로 board-playground 테스트 catalog 외 |
+| 3 profile 부팅 검증 N/A 사유가 schema-level로 검증 가능한가? | O | 소스/의존성/profile 자산 무변경 명시 |
+
+## 7. NEEDS-WORK 항목
+
+없음. 본 PR은 빌드/실행/테스트 영향이 없는 외부 도구 도입이므로, 다음 게이트(`/acceptance-criteria` → `/risk-check` → `/implement` 상응 작업 → `/qa-test --ai`)로 진입.

--- a/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.plan.md
+++ b/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.plan.md
@@ -1,0 +1,96 @@
+---
+doc_type: feature-plan
+version: v0.1 (Draft)
+status: Draft
+author: woosung.ahn@bespinglobal.com
+date: 2026-05-20
+gate: feature
+related:
+  R-ID: []
+  F-ID: []
+  supersedes: null
+---
+
+# code-explainer 플러그인 도입 — Implementation Plan
+
+## 변경 이력
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v0.1 | 2026-05-20 | woosung.ahn | 초안 (scaffold-doc.sh 생성) |
+
+## 1. 커밋 시퀀스 (DAG)
+
+| # | 커밋 | 영향 파일 | 테스트 추가 | 회귀 위험 |
+| --- | --- | --- | --- | --- |
+| C1 | `feat(plugin): add code-explainer plugin scaffolding #54` | `code-explainer-plugin/.claude-plugin/plugin.json`, `code-explainer-plugin/LICENSE`, `code-explainer-plugin/README.md`, `code-explainer-plugin/config.json` | N/A (외부 도구) | 없음 — 신규 디렉토리 추가만 |
+| C2 | `feat(plugin): add SKILL.md with Discussion+Wiki dual sink #54` | `code-explainer-plugin/skills/code-explainer/SKILL.md` | N/A | 없음 — Phase 3.5 Wiki 적재 절차 포함, Phase 0.4 사전 조건 분리 |
+| C3 | `docs(feature): add feat-code-explainer-plugin artifacts #54` | `docs/features/feat-code-explainer-plugin/*.md` (6개) | N/A | 없음 |
+| C4 | `feat(plugin): run plugin against frontend → adopt Discussion+Wiki #54` | (Wiki repo 측 push, board-playground main에는 파일 변경 없음) | N/A (검증은 manual + Discussion/Wiki URL 확인) | 없음 |
+
+> 본 작업은 board-playground 빌드/런타임 코드 변경이 없으므로 C1·C2·C3는 한 커밋으로 묶어도 안전. 다만 변경 의도를 분리 추적하기 위해 권고대로 분리한다.
+
+## 2. 의존성 그래프
+
+```
+C1 (scaffolding 5 files)
+   └─ C2 (SKILL.md with Wiki Phase) ── depends on C1 (.claude-plugin/plugin.json 메타)
+        └─ C3 (feature artifacts 6 files) ── depends on contract.md §0 Referenced-IDs 결정
+             └─ C4 (run plugin) ── depends on C1+C2 plugin 준비 + Wiki repo 초기화 (선행 충족됨, HEAD=a00249481)
+```
+
+## 3. 테스트 매핑
+
+| 커밋 | 테스트 추가 위치 | 시나리오 |
+| --- | --- | --- |
+| C1 | (없음) | 정적 파일 추가만. JSON 문법 유효성은 `jq`로 검증. |
+| C2 | (없음) | SKILL.md는 markdown + 절차 문서. 검증은 C4 실행 결과로 갈음. |
+| C3 | `bash .claude/scripts/validate-doc.sh docs/features/feat-code-explainer-plugin/*.md` | schema-level validation 6개 문서 PASS |
+| C4 | manual — Discussion URL ≥ 37개 생성, Wiki에서 `Home.md`/`_Sidebar.md`/`L1-`/`L2-`/`L3-*` 페이지 push 확인 | end-to-end 적재 검증 |
+
+## 4. 빌드·실행 검증 단계
+
+본 PR은 board-playground의 frontend/backend 빌드에 영향이 없으므로 dev/stg/prod 3 profile 부팅 검증은 **N/A**. 단, 변경 사실을 명시적으로 검증:
+
+```bash
+# 1. JSON 메타파일 유효성
+jq . code-explainer-plugin/.claude-plugin/plugin.json
+jq . code-explainer-plugin/config.json
+
+# 2. SKILL.md frontmatter + 절차 marker 존재 확인
+grep -q "^name: code-explainer" code-explainer-plugin/skills/code-explainer/SKILL.md
+grep -q "Phase 3.5: GitHub Wiki 적재" code-explainer-plugin/skills/code-explainer/SKILL.md
+grep -q "Phase 0.4: Wiki" code-explainer-plugin/skills/code-explainer/SKILL.md || \
+  grep -q "4. Wiki 활성화" code-explainer-plugin/skills/code-explainer/SKILL.md
+
+# 3. 기존 frontend 빌드가 영향받지 않음 (sanity)
+cd frontend && pnpm tsc --noEmit && cd ..
+
+# 4. feature 산출 문서 schema 검증
+for f in docs/features/feat-code-explainer-plugin/*.md; do
+  bash .claude/scripts/validate-doc.sh "$f" || echo "FAIL: $f"
+done
+
+# 5. end-to-end 적재 검증 (수동 실행 후 URL 확인)
+# - https://github.com/sungjunchoi-bespin/board-playground/discussions?discussions_q=label%3AL1+label%3Aboard-playground
+# - https://github.com/sungjunchoi-bespin/board-playground/wiki
+```
+
+### 3 profile 부팅 검증 (ADR-0037 v1.1 + ADR-0040)
+
+**N/A** — 본 PR diff는 `code-explainer-plugin/` + `docs/features/feat-code-explainer-plugin/` 만 포함하며 다음을 모두 만족:
+
+- `frontend/`, `backend/` 소스 변경 없음
+- `frontend/package.json`, `backend/build.gradle` 등 의존성 정의 변경 없음
+- `.env.{dev,stg,prod}.example`, DB migrations, lockfile 변경 없음
+- `12-scaffolding/{java,typescript}.md` §5 빌드 명령 변경 없음
+- `LOCAL.md` §3 profile별 부팅 명령 변경 없음
+
+따라서 dev/stg/prod 부팅 검증을 생략하며, PR 본문 6번째 축에 본 사유를 명시한다.
+
+## 5. 점진 합의 / 결정 발생 항목
+
+- (해소) Wiki 사전 조건 미충족 시 BLOCK vs soft-skip → **soft-skip** (Discussion은 계속 진행, AI 게이트에 영향 없음)
+- (해소) 페이지 명명 규칙 — 슬래시 vs 하이픈 → **하이픈** (`L2-frontend-src-components.md`)
+- (해소) 기존 페이지 처리 — Wiki는 git이라 별도 백업 절차 없음. Discussion은 코멘트 백업.
+- (해소) frontend vs backend 우선 → frontend (파일 수 적어 파일럿으로 적합)

--- a/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.risk.md
+++ b/docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.risk.md
@@ -1,0 +1,80 @@
+---
+doc_type: feature-risk
+version: v0.1 (Draft)
+status: Draft
+author: woosung.ahn@bespinglobal.com
+date: 2026-05-20
+gate: feature
+related:
+  R-ID: []
+  F-ID: []
+  supersedes: null
+---
+
+# code-explainer 플러그인 도입 — Feature Risk
+
+## 변경 이력
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v0.1 | 2026-05-20 | woosung.ahn | 초안 (scaffold-doc.sh 생성) |
+
+## 1. 본 변경의 리스크
+
+| RISK-ID | 제목 | 영향(1~5) | 가능성(1~5) | 등급 |
+| --- | --- | --- | --- | --- |
+| R1 | Wiki repo 인증 실패로 push 누락 | 2 | 2 | **Low** |
+| R2 | LLM 분석 결과의 사실 오류 (잘못된 함수 설명) | 2 | 3 | **Low** |
+| R3 | Discussion ~37개·Wiki ~37 페이지 일괄 적재로 노이즈 알림 폭주 | 1 | 2 | **Low** |
+| R4 | 플러그인 디렉토리가 IDE/빌드 도구에 잘못 인식 (예: TypeScript tsconfig include) | 3 | 1 | **Low** |
+| R5 | config.json `webhook_url` 누설 (이번 PR은 빈 값이라 해당 없음) | 4 | 1 | **Low** |
+
+> 영향 × 가능성 ≥ 9 (High 등급)에 해당하는 리스크 없음.
+
+## 2. 리스크 상세
+
+### R1 — Wiki push 실패
+
+- **발현 조건**: `gh auth setup-git` 실패, 또는 wiki repo가 다시 비초기화 상태로 돌아감
+- **완화**: SKILL.md Phase 3.5에서 Wiki 실패는 soft-fail 처리 — Discussion 적재는 계속, 사용자에게 안내만 출력. PR 본문에 "Wiki: 스킵됨 (사유)" 명시.
+- **탐지**: 적재 직후 `git ls-remote https://github.com/sungjunchoi-bespin/board-playground.wiki.git`로 최신 커밋 확인
+
+### R2 — LLM 사실 오류
+
+- **발현 조건**: Claude가 코드를 잘못 해석하여 함수 의도/리뷰 기준을 오기재
+- **완화**: 학습 문서임을 Wiki Home / Discussion 본문에 명시. "이 문서는 LLM 자동 생성. 사실 확인은 소스 파일 우선". 발견 시 재실행으로 갱신.
+- **탐지**: 휴먼 게이트(D-06 2단)에서 randomly 1~2개 L3 페이지 샘플링하여 코드와 대조
+
+### R3 — 알림 폭주
+
+- **발현 조건**: Repository watchers에게 Discussion 신규 생성 N+ 알림 동시 발송
+- **완화**: 한 번에 ~37개라 발송 빈도는 1회. 후속 backend 도입 시(108개) PR 본문에 적재 시작 시각 안내.
+- **탐지**: 사후 (사용자 피드백)
+
+### R4 — IDE/빌드 도구 인식
+
+- **발현 조건**: tsconfig.json `include`에 `**/*.ts`가 있으면 `code-explainer-plugin/`이 포함될 가능성
+- **완화**: frontend/tsconfig.json은 `"include": ["src"]`로 제한적. backend tsconfig 없음. 즉, 영향 없음.
+- **탐지**: AC-6 (`pnpm tsc --noEmit`) 회귀 인수로 검증
+
+### R5 — webhook URL 누설
+
+- **발현 조건**: 추후 누군가 `webhook_url`을 채우고 그대로 커밋
+- **완화**: 본 PR에서는 `""` 빈 값. SKILL.md Tips와 README에 "webhook_url은 비공개 환경변수로 관리 권장" 후속 작업 항목으로 메모.
+- **탐지**: pre-commit hook(`check-secrets`) 활용 — 현재 settings.json PreToolUse 훅이 시크릿 파일 패턴을 차단함
+
+## 3. High 등급 단계적 롤아웃
+
+해당 없음 — High 등급 리스크 0건. 단일 PR로 일괄 적용.
+
+## 4. 데이터 영속성 변경
+
+- **board-playground DB**: 영향 없음 (`backend/src/main/resources/db/migration/` 미접촉)
+- **GitHub Discussions**: 신규 페이지 ~37개 생성. 기존 페이지 미접촉 (라벨 `board-playground`로 분리됨).
+- **GitHub Wiki**: 신규 페이지 + `Home.md`, `_Sidebar.md` push. 초기화 시 만들었던 사용자 Home 페이지가 덮어쓰여질 수 있음 — **사용자 확인 필요**.
+
+> **사용자 확인 요망**: Wiki 초기화 시 만든 첫 페이지(예: `Home`)가 플러그인의 `Home.md`로 덮어쓰여지는 것이 의도와 일치하는지 머지 전 확인.
+
+## 5. 15-risk.md 갱신 항목
+
+본 변경의 리스크 등급이 모두 Low이고 외부 도구 도입이므로 프로젝트 전역 리스크 레지스터(`docs/planning/15-risk/15-risk.md`) 갱신은 불요.


### PR DESCRIPTION
Closes #54

## Summary

- `code-explainer-plugin/` 디렉토리 도입 (`.claude-plugin/plugin.json`, `SKILL.md`, `config.json`, `README.md`, `LICENSE`).
- **Phase 0.4 (Wiki 사전 조건) + Phase 3.5 (Wiki 적재)** 추가 — `<repo>.wiki.git` clone → `L1-`/`L2-`/`L3-` prefix 페이지 작성 → `Home.md`/`_Sidebar.md` 생성 → commit & push. 사전 조건 실패 시 Wiki만 soft-skip (Discussion은 계속).
- frontend(`frontend/src`, 28 TS/TSX, 8 dir) 대상 **L1 1개 + L2 8개 + L3 28개 = 37개** Discussion + Wiki 페이지 적재 완료.
- `docs/features/feat-code-explainer-plugin/*.md` 6개 산출 문서 (brief/contract/plan/eng-review/acceptance/risk) — 모두 schema-validate PASS.

## Touched Areas (3+ 영역 명시)

- `code-explainer-plugin/` (외부 도구 디렉토리 신규)
- `docs/features/feat-code-explainer-plugin/` (feature artifacts 6개)
- `.gitignore` (plugin output 디렉토리 1줄 추가)

## Flow Mode

- **Mode**: `add`
- **Mode Decision Trace (ADR-0032)**:
  - `type:bug` 라벨/에러 키워드: 0건
  - UI/token/시각 키워드: 0건
  - 기존 동작 변경 / breaking 가능성: 0건
  - **부정 시그널 0건 → 기본값 add 자동 결정** (ADR-0032 §2.1)

## Test Plan (D-06 1단·2단 공유, AI 게이트 6축)

### 1. 단위 / 정적 검증
- [x] `python3 -c "import json; json.load(...)"` — `plugin.json`, `config.json` 유효
- [x] SKILL.md 핵심 헤더 grep — `Phase 3.5: GitHub Wiki 적재`, `4. Wiki 활성화` 모두 존재
- [x] `.claude/scripts/validate-doc.sh` × 6 → 6/6 OK

### 2. 회귀 / Integration
- [x] `cd frontend && pnpm exec tsc --noEmit` → exit 0 (회귀 0건)
- [x] `git diff main -- frontend/ backend/` → 0줄 (소스 무변경)

### 3. End-to-End (Discussion + Wiki 실제 적재)
- [x] Discussion 생성: **37개** (#55~#91)
  - L1: 1, L2: 8, L3: 28
  - 라벨 자동 생성: `L1`, `L2`, `L3`, `board-playground`
  - 인덱스: https://github.com/sungjunchoi-bespin/board-playground/discussions?discussions_q=label%3Aboard-playground
- [x] Wiki Home + _Sidebar + 37 페이지 push 완료
  - Home: https://github.com/sungjunchoi-bespin/board-playground/wiki

### 4. AI 게이트 6축 매트릭스

| 축 | 결과 | 비고 |
|---|---|---|
| 1. 단위 테스트 | N/A | 외부 도구, board-playground 빌드 미접촉 |
| 2. 정적 검증 (lint/type) | ✅ | frontend tsc PASS, JSON 유효 |
| 3. 회귀 (기존 테스트) | ✅ | 소스 무변경 |
| 4. 보안 | ✅ | `webhook_url=""` 빈 값, 시크릿 0건 |
| 5. UI 골든패스 + stylesheet | **N/A** | `ui_changed=false`, `frontend/`·`backend/` 디렉토리 미접촉 (ADR-0011 + ADR-0038 stylesheet 축 충족 사유 명시) |
| 6. dev/stg/prod 3 profile 부팅 | **N/A** | 빌드/profile 자산 미변경 — `.env.*.example`·migrations·lockfile·`LOCAL.md` §3 모두 무변경 (ADR-0037 v1.1 + ADR-0040 N/A 사유) |

## Acceptance Criteria (DoD)

`docs/features/feat-code-explainer-plugin/feat-code-explainer-plugin.acceptance.md` 참조.

- [x] AC-1 ~ AC-7 모두 PASS
- [x] feature schema-validate 6/6
- [x] AI 게이트 6축
- [ ] (휴먼 게이트) `tested` 라벨 부착 + Approve ≥ 1

## 결과 URL

- 📋 **Discussion 인덱스** (label:board-playground 필터): https://github.com/sungjunchoi-bespin/board-playground/discussions?discussions_q=label%3Aboard-playground
- 📚 **Wiki Home**: https://github.com/sungjunchoi-bespin/board-playground/wiki
- 🏗️ **L1 Discussion**: https://github.com/sungjunchoi-bespin/board-playground/discussions/55

## Notes

- 이번 PR은 frontend 파일럿. backend(108 파일) 적재는 후속 이슈로 분리 예정 — `feat-code-explainer-backend` slug 권장.
- Plugin 본체(`code-explainer-plugin/`)는 board-playground 빌드 의존이 없으므로 `git revert` 1회로 100% 롤백 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)